### PR TITLE
Changes Localizer and Unlocalizer names

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_NUMBER_VERSION', '0.3' );
+define( 'DATAVALUES_NUMBER_VERSION', '0.4' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ DataValues Number has been written by Daniel Kinzler, as [Wikimedia Germany]
 
 ## Release notes
 
-### 0.3.1 (dev)
+### 0.4 (dev)
+
+* Unlocalizer interface renamed to NumberUnlocalizer
+* Localizer interface renamed to NumberLocalizer
+* BasicUnlocalizer interface renamed to BasicNumberUnlocalizer
+* BasicLocalizer interface renamed to BasicNumberLocalizer
 
 ### 0.3 (2014-03-12)
+
 * Unlocalizer: added getNumberRegex() and getUnitRegex()
 * Unlocalizer: replaced unlocalize() with unlocalizeNumber()
 * Localizer: replaced localize() with localizeNumber()

--- a/src/ValueFormatters/BasicNumberLocalizer.php
+++ b/src/ValueFormatters/BasicNumberLocalizer.php
@@ -12,7 +12,7 @@ namespace ValueFormatters;
  * @licence GNU GPL v2+
  * @author Daniel Kinzler
  */
-class BasicLocalizer implements Localizer {
+class BasicNumberLocalizer implements NumberLocalizer {
 
 	/**
 	 * @see Localizer::localizeNumber()

--- a/src/ValueFormatters/DecimalFormatter.php
+++ b/src/ValueFormatters/DecimalFormatter.php
@@ -23,21 +23,21 @@ class DecimalFormatter extends ValueFormatterBase {
 	const OPT_FORCE_SIGN = 'forceSign';
 
 	/**
-	 * @var Localizer
+	 * @var NumberLocalizer
 	 */
 	protected $localizer;
 
 	/**
 	 * @param FormatterOptions $options
-	 * @param Localizer|null $localizer
+	 * @param NumberLocalizer|null $localizer
 	 */
-	public function __construct( FormatterOptions $options, Localizer $localizer = null ) {
+	public function __construct( FormatterOptions $options, NumberLocalizer $localizer = null ) {
 		$options->defaultOption( self::OPT_FORCE_SIGN, false );
 
 		parent::__construct( $options );
 
 		if ( !$localizer ) {
-			$localizer = new BasicLocalizer();
+			$localizer = new BasicNumberLocalizer();
 		}
 
 		$this->localizer = $localizer;

--- a/src/ValueFormatters/NumberLocalizer.php
+++ b/src/ValueFormatters/NumberLocalizer.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
  * @licence GNU GPL v2+
  * @author Daniel Kinzler
  */
-interface Localizer {
+interface NumberLocalizer {
 
 	/**
 	 * Localizes a number.

--- a/src/ValueParsers/BasicNumberUnlocalizer.php
+++ b/src/ValueParsers/BasicNumberUnlocalizer.php
@@ -12,7 +12,7 @@ namespace ValueParsers;
  * @license GPL 2+
  * @author Daniel Kinzler
  */
-class BasicUnlocalizer implements Unlocalizer {
+class BasicNumberUnlocalizer implements NumberUnlocalizer {
 
 	/**
 	 * Converts a localized number to canonical/internal representation.

--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -22,7 +22,7 @@ class DecimalParser extends StringValueParser {
 	private $math;
 
 	/**
-	 * @var null|Unlocalizer
+	 * @var null|NumberUnlocalizer
 	 */
 	protected $unlocalizer;
 
@@ -30,13 +30,13 @@ class DecimalParser extends StringValueParser {
 	 * @since 0.1
 	 *
 	 * @param ParserOptions|null $options
-	 * @param Unlocalizer|null $unlocalizer
+	 * @param NumberUnlocalizer|null $unlocalizer
 	 */
-	public function __construct( ParserOptions $options = null, Unlocalizer $unlocalizer = null ) {
+	public function __construct( ParserOptions $options = null, NumberUnlocalizer $unlocalizer = null ) {
 		parent::__construct( $options );
 
 		if ( !$unlocalizer ) {
-			$unlocalizer = new BasicUnlocalizer();
+			$unlocalizer = new BasicNumberUnlocalizer();
 		}
 
 		$this->unlocalizer = $unlocalizer;

--- a/src/ValueParsers/NumberUnlocalizer.php
+++ b/src/ValueParsers/NumberUnlocalizer.php
@@ -12,7 +12,7 @@ namespace ValueParsers;
  * @license GPL 2+
  * @author Daniel Kinzler
  */
-interface Unlocalizer {
+interface NumberUnlocalizer {
 
 	/**
 	 * Converts a localized number to canonical/internal representation.

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -23,7 +23,7 @@ class QuantityParser extends StringValueParser {
 	protected $decimalParser;
 
 	/**
-	 * @var Unlocalizer
+	 * @var NumberUnlocalizer
 	 */
 	protected $unlocalizer;
 
@@ -31,13 +31,13 @@ class QuantityParser extends StringValueParser {
 	 * @since 0.1
 	 *
 	 * @param ParserOptions|null $options
-	 * @param Unlocalizer $unlocalizer
+	 * @param NumberUnlocalizer $unlocalizer
 	 */
-	public function __construct( ParserOptions $options = null, Unlocalizer $unlocalizer = null ) {
+	public function __construct( ParserOptions $options = null, NumberUnlocalizer $unlocalizer = null ) {
 		parent::__construct( $options );
 
 		if ( !$unlocalizer ) {
-			$unlocalizer = new BasicUnlocalizer();
+			$unlocalizer = new BasicNumberUnlocalizer();
 		}
 
 		$this->decimalParser = new DecimalParser( $options, $unlocalizer );

--- a/tests/ValueFormatters/BasicLocalizerTest.php
+++ b/tests/ValueFormatters/BasicLocalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace ValueParsers\Test;
 
-use ValueFormatters\BasicLocalizer;
+use ValueFormatters\BasicNumberLocalizer;
 
 /**
  * @covers ValueFormatters\BasicLocalizer
@@ -36,7 +36,7 @@ class BasicLocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideLocalizeNumber
 	 */
 	public function testLocalizeNumber( $localized, $expected ) {
-		$unlocalizer = new BasicLocalizer();
+		$unlocalizer = new BasicNumberLocalizer();
 		$unlocalized = $unlocalizer->localizeNumber( $localized );
 
 		$this->assertEquals( $expected, $unlocalized );

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -66,7 +66,7 @@ class DecimalFormatterTest extends ValueFormatterTestBase {
 	}
 
 	public function testLocalization() {
-		$localizer = $this->getMock( 'ValueFormatters\Localizer' );
+		$localizer = $this->getMock( 'ValueFormatters\NumberLocalizer' );
 
 		$localizer->expects( $this->once() )
 			->method( 'localizeNumber' )

--- a/tests/ValueParsers/BasicUnlocalizerTest.php
+++ b/tests/ValueParsers/BasicUnlocalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace ValueParsers\Test;
 
-use ValueParsers\BasicUnlocalizer;
+use ValueParsers\BasicNumberUnlocalizer;
 
 /**
  * @covers ValueParsers\BasicUnlocalizer
@@ -51,7 +51,7 @@ class BasicUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideUnlocalizeNumber
 	 */
 	public function testUnlocalizeNumber( $localized, $expected ) {
-		$unlocalizer = new BasicUnlocalizer();
+		$unlocalizer = new BasicNumberUnlocalizer();
 		$unlocalized = $unlocalizer->unlocalizeNumber( $localized );
 
 		$this->assertEquals( $expected, $unlocalized );
@@ -85,7 +85,7 @@ class BasicUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideGetNumberRegexMatch
 	 */
 	public function testGetNumberRegexMatch( $value ) {
-		$unlocalizer = new BasicUnlocalizer();
+		$unlocalizer = new BasicNumberUnlocalizer();
 		$regex = $unlocalizer->getNumberRegex();
 
 		$this->assertTrue( (bool)preg_match( "/^($regex)$/u", $value ) );
@@ -122,7 +122,7 @@ class BasicUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideGetNumberRegexMismatch
 	 */
 	public function testGetNumberRegexMismatch( $value ) {
-		$unlocalizer = new BasicUnlocalizer();
+		$unlocalizer = new BasicNumberUnlocalizer();
 		$regex = $unlocalizer->getNumberRegex();
 
 		$this->assertFalse( (bool)preg_match( "/^($regex)$/u", $value ) );
@@ -156,7 +156,7 @@ class BasicUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideGetUnitRegexMatch
 	 */
 	public function testGetUnitRegexMatch( $value ) {
-		$unlocalizer = new BasicUnlocalizer();
+		$unlocalizer = new BasicNumberUnlocalizer();
 		$regex = $unlocalizer->getUnitRegex();
 
 		$this->assertTrue( (bool)preg_match( "/^($regex)$/u", $value ) );
@@ -185,7 +185,7 @@ class BasicUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideGetUnitRegexMismatch
 	 */
 	public function testGetUnitRegexMismatch( $value ) {
-		$unlocalizer = new BasicUnlocalizer();
+		$unlocalizer = new BasicNumberUnlocalizer();
 		$regex = $unlocalizer->getUnitRegex();
 
 		$this->assertFalse( (bool)preg_match( "/^($regex)$/u", $value ) );

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -103,7 +103,7 @@ class DecimalParserTest extends StringValueParserTest {
 	}
 
 	public function testUnlocalization() {
-		$unlocalizer = $this->getMock( 'ValueParsers\Unlocalizer' );
+		$unlocalizer = $this->getMock( 'ValueParsers\NumberUnlocalizer' );
 
 		$unlocalizer->expects( $this->once() )
 			->method( 'unlocalizeNumber' )

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -3,7 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\QuantityValue;
-use ValueParsers\BasicUnlocalizer;
+use ValueParsers\BasicNumberUnlocalizer;
 use ValueParsers\QuantityParser;
 use ValueParsers\ValueParser;
 
@@ -164,13 +164,13 @@ class QuantityParserTest extends StringValueParserTest {
 		$options = $this->newParserOptions();
 
 		$class = $this->getParserClass();
-		return new $class( $options, new BasicUnlocalizer() );
+		return new $class( $options, new BasicNumberUnlocalizer() );
 	}
 
 	public function testParseLocalizedQuantity() {
 		$options = $this->newParserOptions( array( ValueParser::OPT_LANG => 'test' ) );
 
-		$unlocalizer = $this->getMock( 'ValueParsers\Unlocalizer' );
+		$unlocalizer = $this->getMock( 'ValueParsers\NumberUnlocalizer' );
 
 		$charmap = array(
 			' ' => '',


### PR DESCRIPTION
As everything is in the ValueParsers namespace
the current nammig was very missleading for the
expected scope of the classes and interfaces.

They should only be used for numbers and thus
should reflect this in the name as we are not
using further namespaces in DataValues (yet)

ChangeLog is also updated

No need to make a release after this, this is just clearing stuff up ready for the next one...
