### PR TITLE
Fix non-consistent constructor tests

### DIFF
--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -51,9 +51,6 @@ class DecimalValueTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
-		$argLists[] = array();
-
-
 		$argLists[] = array( 'foo' );
 		$argLists[] = array( '' );
 		$argLists[] = array( '4.2' );
@@ -315,4 +312,5 @@ class DecimalValueTest extends DataValueTest {
 			array( new DecimalValue( '-0.001' ),   false ),
 		);
 	}
+
 }

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -40,7 +40,6 @@ class QuantityValueTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
-		$argLists[] = array();
 		$argLists[] = array( new DecimalValue( '+0' ), '', new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
 		$argLists[] = array( new DecimalValue( '+0' ), 1, new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
 


### PR DESCRIPTION
Having no arguments in a constructor is not the same as having invalid arguments. Type hinted arguments are required. Depending on the PHP version and configuration this may throw an exception (as expected in the test) or trigger an other type of PHP error (and make the test fail).
