### PR TITLE
Fix outdated PHPDoc tags

### DIFF
--- a/src/DataValues/DecimalMath.php
+++ b/src/DataValues/DecimalMath.php
@@ -202,7 +202,9 @@ class DecimalMath {
 	 * @example: the position of exponent -2 in "+1.037" is 4.
 	 *
 	 * @param int $exponent
-	 * @param string $decimal
+	 * @param DecimalValue $decimal
+	 *
+	 * @return int
 	 */
 	public function getPositionForExponent( $exponent, DecimalValue $decimal ) {
 		$decimal = $decimal->getValue();

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -110,9 +110,14 @@ class QuantityValue extends DataValueObject {
 	}
 
 	/**
-	 * @see self::newFromNumber()
+	 * @see newFromNumber
 	 *
-	 * @deprecated use newFromNumber() instead
+	 * @deprecated since 0.1, use newFromNumber instead
+	 *
+	 * @param string|int|float|DecimalValue $amount
+	 * @param string $unit
+	 * @param string|int|float|DecimalValue|null $upperBound
+	 * @param string|int|float|DecimalValue|null $lowerBound
 	 *
 	 * @return QuantityValue
 	 */


### PR DESCRIPTION
Copy-pasting the parameter list avoids warnings in code analysis tools about incomplete doc tags.