### PR TITLE
Correctly detect precision for scientific notation.

### DIFF
--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -5,6 +5,7 @@ namespace ValueParsers;
 use DataValues\DecimalMath;
 use DataValues\DecimalValue;
 use DataValues\IllegalValueException;
+use InvalidArgumentException;
 
 /**
  * ValueParser that parses the string representation of a decimal number.
@@ -52,6 +53,50 @@ class DecimalParser extends StringValueParser {
 	}
 
 	/**
+	 * Splits the exponent from the scientific notation of a decimal number.
+	 *
+	 * @example splitDecimalExponent( '1.2' )  is  array( '1.2', 0 )
+	 * @example splitDecimalExponent( '1.2e3' )  is  array( '1.2', 3 )
+	 * @example splitDecimalExponent( '1.2e-2' )  is  array( '1.2', -2 )
+	 *
+	 * @param string $valueString A decimal string, possibly using scientific notation.
+	 *
+	 * @return array list( $decimal, $exponent ) A pair of the decimal value without the
+	 *         decimal exponent, and the decimal exponent as an integer. If $valueString
+	 *         does not use scientific notation, $exponent will be 0.
+	 */
+	public function splitDecimalExponent( $valueString ) {
+		if ( preg_match( '/^(.*)([eE]|x10\^)([-+]?[,\d]+)$/', $valueString, $matches ) ) {
+			$exponent = $this->normalizeDecimal( $matches[3] );
+			return array( $matches[1], intval( $exponent ) );
+		}
+
+		return array( $valueString, 0 );
+	}
+
+	/**
+	 * Applies a decimal exponent, by shifting the decimal point in the decimal string
+	 * representation of the value.
+	 *
+	 * @example applyDecimalExponent( new DecimalValue( '1.2' ), 0 )  is  new DecimalValue( '1.2' )
+	 * @example applyDecimalExponent( new DecimalValue( '1.2' ), 3 )  is  new DecimalValue( '1200' )
+	 * @example applyDecimalExponent( new DecimalValue( '1.2' ), -2 )  is  new DecimalValue( '0.012' )
+	 *
+	 * @param DecimalValue $decimal
+	 * @param int $exponent
+	 *
+	 * @return DecimalValue
+	 */
+	public function applyDecimalExponent( DecimalValue $decimal, $exponent ) {
+		if ( $exponent !== 0 ) {
+			$math = $this->getMath();
+			$decimal = $math->shift( $decimal, $exponent );
+		}
+
+		return $decimal;
+	}
+
+	/**
 	 * Creates a DecimalValue from a given string.
 	 *
 	 * The decimal notation for the value is based on ISO 31-0, with some modifications:
@@ -79,14 +124,7 @@ class DecimalParser extends StringValueParser {
 		$value = $this->unlocalizer->unlocalizeNumber( $value );
 
 		//handle scientific notation
-		if ( preg_match( '/^(.*)([eE]|x10\^)([-+]?[,\d]+)$/', $value, $matches ) ) {
-			$exponent = $this->normalizeDecimal( $matches[3] );
-			$exponent = intval( $exponent );
-
-			$value = $matches[1];
-		} else {
-			$exponent = 0;
-		}
+		list( $value, $exponent ) = $this->splitDecimalExponent( $value );
 
 		$value = $this->normalizeDecimal( $value );
 
@@ -96,11 +134,7 @@ class DecimalParser extends StringValueParser {
 
 		try {
 			$decimal = new DecimalValue( $value );
-
-			if ( $exponent ) {
-				$math = $this->getMath();
-				$decimal = $math->shift( $decimal, $exponent );
-			}
+			$decimal = $this->applyDecimalExponent( $decimal, $exponent );
 
 			return $decimal;
 		} catch ( IllegalValueException $ex ) {

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -100,18 +100,23 @@ class QuantityParser extends StringValueParser {
 	 * @return QuantityValue
 	 */
 	private function newQuantityFromParts( $amount, $exactness, $margin, $unit ) {
+		list( $amount, $exponent ) = $this->decimalParser->splitDecimalExponent( $amount );
 		$amountValue = $this->decimalParser->parse( $amount );
 
 		if ( $exactness === '!' ) {
 			// the amount is an exact number
+			$amountValue = $this->decimalParser->applyDecimalExponent( $amountValue, $exponent );
 			$quantity = $this->newExactQuantity( $amountValue, $unit );
 		} elseif ( $margin !== null ) {
 			// uncertainty margin given
+			// NOTE: the pattern for scientific notation is 2e3 +/- 1e2, so the exponents are treated separately.
 			$marginValue = $this->decimalParser->parse( $margin );
+			$amountValue = $this->decimalParser->applyDecimalExponent( $amountValue, $exponent );
 			$quantity = $this->newUncertainQuantityFromMargin( $amountValue, $unit, $marginValue );
 		} else {
 			// derive uncertainty from given decimals
-			$quantity = $this->newUncertainQuantityFromDigits( $amountValue, $unit );
+			// NOTE: with scientific notation, the exponent applies to the uncertainty bounds, too
+			$quantity = $this->newUncertainQuantityFromDigits( $amountValue, $unit, $exponent );
 		}
 
 		return $quantity;
@@ -220,11 +225,11 @@ class QuantityParser extends StringValueParser {
 	 *
 	 * @param DecimalValue $amount The quantity
 	 * @param string $unit The quantity's unit (use "1" for unit-less quantities)
+	 * @param int $exponent Decimal exponent to apply
 	 *
 	 * @return QuantityValue
-	 * @throws IllegalValueException
 	 */
-	private function newUncertainQuantityFromDigits( DecimalValue $amount, $unit = '1' ) {
+	private function newUncertainQuantityFromDigits( DecimalValue $amount, $unit = '1', $exponent = 0 ) {
 		$math = new DecimalMath();
 
 		if ( $amount->getSign() === '+' ) {
@@ -234,6 +239,10 @@ class QuantityParser extends StringValueParser {
 			$upperBound = $math->slump( $amount );
 			$lowerBound = $math->bump( $amount );
 		}
+
+		$amount = $this->decimalParser->applyDecimalExponent( $amount, $exponent );
+		$lowerBound = $this->decimalParser->applyDecimalExponent( $lowerBound, $exponent );
+		$upperBound = $this->decimalParser->applyDecimalExponent( $upperBound, $exponent );
 
 		return new QuantityValue( $amount, $unit, $upperBound, $lowerBound );
 	}

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -121,4 +121,43 @@ class DecimalParserTest extends StringValueParserTest {
 		$this->assertEquals( '20000000', $value->getValue() );
 	}
 
+	public function provideSplitDecimalExponent() {
+		return array(
+			'no exponent' => array( '1.2', '1.2', 0 ),
+			'exponent' => array( '1.2E3', '1.2', 3 ),
+			'negative exponent' => array( '+1.2e-2', '+1.2', -2 ),
+			'positive exponent' => array( '-12e+3', '-12', 3 ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideSplitDecimalExponent
+	 */
+	public function testSplitDecimalExponent( $valueString, $expectedDecimal, $expectedExponent ) {
+		$parser = new DecimalParser();
+		list( $decimal, $exponent ) = $parser->splitDecimalExponent( $valueString );
+
+		$this->assertSame( $expectedDecimal, $decimal );
+		$this->assertSame( $expectedExponent, $exponent );
+	}
+
+
+	public function provideApplyDecimalExponent() {
+		return array(
+			'no exponent' => array( new DecimalValue( '+1.2' ), 0, new DecimalValue( '+1.2' ) ),
+			'negative exponent' => array( new DecimalValue( '-1.2' ), -2, new DecimalValue( '-0.012' ) ),
+			'positive exponent' => array( new DecimalValue( '-12' ), 3, new DecimalValue( '-12000' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideApplyDecimalExponent
+	 */
+	public function testApplyDecimalExponent( DecimalValue $decimal, $exponent, DecimalValue $expectedDecimal ) {
+		$parser = new DecimalParser();
+		$actualDecimal = $parser->applyDecimalExponent( $decimal, $exponent );
+
+		$this->assertSame( $expectedDecimal->getValue(), $actualDecimal->getValue() );
+	}
+
 }

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -18,10 +18,6 @@ class DecimalParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -67,6 +63,9 @@ class DecimalParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see ValueParserTestBase::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 
@@ -121,17 +120,23 @@ class DecimalParserTest extends StringValueParserTest {
 		$this->assertEquals( '20000000', $value->getValue() );
 	}
 
-	public function provideSplitDecimalExponent() {
+	public function splitDecimalExponentProvider() {
 		return array(
 			'no exponent' => array( '1.2', '1.2', 0 ),
 			'exponent' => array( '1.2E3', '1.2', 3 ),
 			'negative exponent' => array( '+1.2e-2', '+1.2', -2 ),
 			'positive exponent' => array( '-12e+3', '-12', 3 ),
+			'leading zero' => array( '12e+09', '12', 9 ),
+			'trailing decimal point' => array( '12.e+3', '12.', 3 ),
+			'leading decimal point' => array( '.12e+3', '.12', 3 ),
+			'space' => array( '12 e+3', '12 ', 3 ),
+			'x10 syntax' => array( '12x10^3', '12', 3 ),
+			'comma' => array( '12e3,4', '12', 34 ),
 		);
 	}
 
 	/**
-	 * @dataProvider provideSplitDecimalExponent
+	 * @dataProvider splitDecimalExponentProvider
 	 */
 	public function testSplitDecimalExponent( $valueString, $expectedDecimal, $expectedExponent ) {
 		$parser = new DecimalParser();
@@ -141,8 +146,7 @@ class DecimalParserTest extends StringValueParserTest {
 		$this->assertSame( $expectedExponent, $exponent );
 	}
 
-
-	public function provideApplyDecimalExponent() {
+	public function applyDecimalExponentProvider() {
 		return array(
 			'no exponent' => array( new DecimalValue( '+1.2' ), 0, new DecimalValue( '+1.2' ) ),
 			'negative exponent' => array( new DecimalValue( '-1.2' ), -2, new DecimalValue( '-0.012' ) ),
@@ -151,7 +155,7 @@ class DecimalParserTest extends StringValueParserTest {
 	}
 
 	/**
-	 * @dataProvider provideApplyDecimalExponent
+	 * @dataProvider applyDecimalExponentProvider
 	 */
 	public function testApplyDecimalExponent( DecimalValue $decimal, $exponent, DecimalValue $expectedDecimal ) {
 		$parser = new DecimalParser();

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -49,6 +49,10 @@ class QuantityParserTest extends StringValueParserTest {
 			'1.4e' => QuantityValue::newFromNumber( '+1.4', 'e', '+1.5', '+1.3' ),
 			'12e3e4' => QuantityValue::newFromNumber( '+12000', 'e4', '+13000', '+11000' ),
 			// FIXME: Add support for 12x10^3, see DecimalParser.
+			'0.004e3' => QuantityValue::newFromNumber( '+4', '1', '+5', '+3' ),
+			'0.004e-3' => QuantityValue::newFromNumber( '+0.000004', '1', '+0.000005', '+0.000003' ),
+			'4000e3' => QuantityValue::newFromNumber( '+4000000', '1', '+4001000', '+3999000' ),
+			'4000e-3' => QuantityValue::newFromNumber( '+4.000', '1', '+4.001', '+3.999' ),
 
 			// precision
 			'0!' => QuantityValue::newFromNumber( 0, '1', 0, 0 ),

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -46,9 +46,9 @@ class QuantityParserTest extends StringValueParserTest {
 			'2.1250' => QuantityValue::newFromNumber( '+2.1250', '1', '+2.1251', '+2.1249' ),
 
 			'1.4e-2' => QuantityValue::newFromNumber( '+0.014', '1', '+0.015', '+0.013' ),
-			'1.4e3' => QuantityValue::newFromNumber( '+1400', '1', '+1401', '+1399' ),
+			'1.4e3' => QuantityValue::newFromNumber( '+1400', '1', '+1500', '+1300' ),
 			'1.4e3!m' => QuantityValue::newFromNumber( '+1400', 'm', '+1400', '+1400' ),
-			'1.4e3m2' => QuantityValue::newFromNumber( '+1400', 'm2', '+1401', '+1399' ),
+			'1.4e3m2' => QuantityValue::newFromNumber( '+1400', 'm2', '+1500', '+1300' ),
 			'1.4ev' => QuantityValue::newFromNumber( '+1.4', 'ev', '+1.5', '+1.3' ),
 			'1.4e' => QuantityValue::newFromNumber( '+1.4', 'e', '+1.5', '+1.3' ),
 
@@ -67,6 +67,9 @@ class QuantityParserTest extends StringValueParserTest {
 
 			'5.3 +/- +0.2' => QuantityValue::newFromNumber( '+5.3', '1', '+5.5', '+5.1' ),
 			'5.3+-+0.2' => QuantityValue::newFromNumber( '+5.3', '1', '+5.5', '+5.1' ),
+
+			'5.3e3 +/- 0.2e2' => QuantityValue::newFromNumber( '+5300', '1', '+5320', '+5280' ),
+			'2e-2+/-1.1e-1' => QuantityValue::newFromNumber( '+0.02', '1', '+0.13', '-0.09' ),
 
 			// negative
 			'5.3 +/- -0.2' => QuantityValue::newFromNumber( '+5.3', '1', '+5.5', '+5.1' ),

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -20,10 +20,6 @@ class QuantityParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$amounts = array(
@@ -51,6 +47,8 @@ class QuantityParserTest extends StringValueParserTest {
 			'1.4e3m2' => QuantityValue::newFromNumber( '+1400', 'm2', '+1500', '+1300' ),
 			'1.4ev' => QuantityValue::newFromNumber( '+1.4', 'ev', '+1.5', '+1.3' ),
 			'1.4e' => QuantityValue::newFromNumber( '+1.4', 'e', '+1.5', '+1.3' ),
+			'12e3e4' => QuantityValue::newFromNumber( '+12000', 'e4', '+13000', '+11000' ),
+			// FIXME: Add support for 12x10^3, see DecimalParser.
 
 			// precision
 			'0!' => QuantityValue::newFromNumber( 0, '1', 0, 0 ),
@@ -95,6 +93,9 @@ class QuantityParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see ValueParserTestBase::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 


### PR DESCRIPTION
The uncertainty interval for 12e3 should be 11e3..13e3.

Bug: [T61768](https://phabricator.wikimedia.org/T61768)