### PR TITLE
Simplify options handling

### DIFF
--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -37,11 +37,7 @@ class DecimalParser extends StringValueParser {
 	public function __construct( ParserOptions $options = null, NumberUnlocalizer $unlocalizer = null ) {
 		parent::__construct( $options );
 
-		if ( !$unlocalizer ) {
-			$unlocalizer = new BasicNumberUnlocalizer();
-		}
-
-		$this->unlocalizer = $unlocalizer;
+		$this->unlocalizer = $unlocalizer ?: new BasicNumberUnlocalizer();
 	}
 
 	/**

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -47,12 +47,8 @@ class QuantityParser extends StringValueParser {
 
 		$this->defaultOption( self::OPT_UNIT, null );
 
-		if ( !$unlocalizer ) {
-			$unlocalizer = new BasicNumberUnlocalizer();
-		}
-
-		$this->decimalParser = new DecimalParser( $options, $unlocalizer );
-		$this->unlocalizer = $unlocalizer;
+		$this->unlocalizer = $unlocalizer ?: new BasicNumberUnlocalizer();
+		$this->decimalParser = new DecimalParser( $this->getOptions(), $this->unlocalizer );
 	}
 
 	/**

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -4,7 +4,6 @@ namespace ValueParsers\Test;
 
 use DataValues\DecimalValue;
 use ValueParsers\DecimalParser;
-use ValueParsers\ParserOptions;
 
 /**
  * @covers ValueParsers\DecimalParser
@@ -114,8 +113,7 @@ class DecimalParserTest extends StringValueParserTest {
 		$unlocalizer->expects( $this->never() )
 			->method( 'getUnitRegex' );
 
-		$options = new ParserOptions();
-		$parser = new DecimalParser( $options, $unlocalizer );
+		$parser = new DecimalParser( null, $unlocalizer );
 
 		$input = '###20#000#000###';
 		$value = $parser->parse( $input );

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -3,7 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\QuantityValue;
-use ValueParsers\BasicNumberUnlocalizer;
+use ValueParsers\ParserOptions;
 use ValueParsers\QuantityParser;
 use ValueParsers\ValueParser;
 
@@ -155,18 +155,14 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	/**
-	 * @since 0.1
 	 * @return QuantityParser
 	 */
 	protected function getInstance() {
-		$options = $this->newParserOptions();
-
-		$class = $this->getParserClass();
-		return new $class( $options, new BasicNumberUnlocalizer() );
+		return new QuantityParser();
 	}
 
 	public function testParseLocalizedQuantity() {
-		$options = $this->newParserOptions();
+		$options = new ParserOptions();
 		$options->setOption( ValueParser::OPT_LANG, 'test' );
 
 		$unlocalizer = $this->getMock( 'ValueParsers\NumberUnlocalizer' );
@@ -201,7 +197,7 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	public function testUnitOption() {
-		$options = $this->newParserOptions();
+		$options = new ParserOptions();
 		$options->setOption( QuantityParser::OPT_UNIT, 'kittens' );
 
 		$parser = new QuantityParser( $options );
@@ -211,7 +207,7 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	public function testUnitOption_conflict() {
-		$options = $this->newParserOptions( array( QuantityParser::OPT_UNIT => 'kittens' ) );
+		$options = new ParserOptions();
 		$options->setOption( QuantityParser::OPT_UNIT, 'kittens' );
 
 		$parser = new QuantityParser( $options );


### PR DESCRIPTION
This removes quite some obsolete code.

Originally the goal was to remove the unused newParserOptions method and to simplify the getInstance methods as much as possible. The additional changes are very closely related.