### PR TITLE
Avoid calling getOptions

### DIFF
--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -48,7 +48,7 @@ class QuantityParser extends StringValueParser {
 		$this->defaultOption( self::OPT_UNIT, null );
 
 		$this->unlocalizer = $unlocalizer ?: new BasicNumberUnlocalizer();
-		$this->decimalParser = new DecimalParser( $this->getOptions(), $this->unlocalizer );
+		$this->decimalParser = new DecimalParser( $this->options, $this->unlocalizer );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class QuantityParser extends StringValueParser {
 	protected function stringParse( $value ) {
 		list( $amount, $exactness, $margin, $unit ) = $this->splitQuantityString( $value );
 
-		$unitOption = $this->getOptions()->getOption( self::OPT_UNIT );
+		$unitOption = $this->getOption( self::OPT_UNIT );
 
 		if ( $unit === null ) {
 			if ( $unitOption !== null ) {


### PR DESCRIPTION
Either use the shortcut methods or access the protected var directly.