### PR TITLE
Deprecate getFormatterClass in favor of getInstance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "~0.1",
+		"data-values/interfaces": "^0.1.5",
 		"data-values/common": "~0.2"
 	},
 	"autoload": {

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -43,7 +43,7 @@ class QuantityFormatter extends ValueFormatterBase {
 	protected $decimalMath;
 
 	/**
-	 * @var DecimalMath
+	 * @var DecimalFormatter
 	 */
 	protected $decimalFormatter;
 
@@ -51,6 +51,7 @@ class QuantityFormatter extends ValueFormatterBase {
 	 * @param DecimalFormatter|null $decimalFormatter
 	 * @param FormatterOptions|null $options
 	 */
+	// FIXME: In all other ValueFormatters the FormatterOption parameter is the first one.
 	public function __construct( DecimalFormatter $decimalFormatter = null, FormatterOptions $options = null ) {
 		parent::__construct( $options );
 

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -18,6 +18,24 @@ use ValueFormatters\FormatterOptions;
 class DecimalFormatterTest extends ValueFormatterTestBase {
 
 	/**
+	 * @deprecated since 0.2, just use getInstance.
+	 */
+	protected function getFormatterClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueFormatterTestBase::getInstance
+	 *
+	 * @param FormatterOptions|null $options
+	 *
+	 * @return DecimalFormatter
+	 */
+	protected function getInstance( FormatterOptions $options = null ) {
+		return new DecimalFormatter( $options );
+	}
+
+	/**
 	 * @see ValueFormatterTestBase::validProvider
 	 *
 	 * @since 0.1
@@ -46,17 +64,6 @@ class DecimalFormatterTest extends ValueFormatterTestBase {
 		}
 
 		return $argLists;
-	}
-
-	/**
-	 * @see ValueFormatterTestBase::getFormatterClass
-	 *
-	 * @since 0.1
-	 *
-	 * @return string
-	 */
-	protected function getFormatterClass() {
-		return 'ValueFormatters\DecimalFormatter';
 	}
 
 	public function testLocalization() {

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -6,7 +6,6 @@ use DataValues\QuantityValue;
 use ValueFormatters\DecimalFormatter;
 use ValueFormatters\FormatterOptions;
 use ValueFormatters\QuantityFormatter;
-use ValueFormatters\ValueFormatter;
 
 /**
  * @covers ValueFormatters\QuantityFormatter
@@ -18,6 +17,24 @@ use ValueFormatters\ValueFormatter;
  * @author Daniel Kinzler
  */
 class QuantityFormatterTest extends ValueFormatterTestBase {
+
+	/**
+	 * @deprecated since 0.2, just use getInstance.
+	 */
+	protected function getFormatterClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueFormatterTestBase::getInstance
+	 *
+	 * @param FormatterOptions|null $options
+	 *
+	 * @return QuantityFormatter
+	 */
+	protected function getInstance( FormatterOptions $options = null ) {
+		return new QuantityFormatter( new DecimalFormatter( $options ), $options );
+	}
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
@@ -72,30 +89,6 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 
 			'+3.125/fs' => array( QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '+3.13', $forceSign ),
 		);
-	}
-
-	/**
-	 * @see ValueFormatterTestBase::getFormatterClass
-	 *
-	 * @since 0.1
-	 *
-	 * @return string
-	 */
-	protected function getFormatterClass() {
-		return 'ValueFormatters\QuantityFormatter';
-	}
-
-	/**
-	 * @see ValueFormatterTestBase::getInstance
-	 *
-	 * @param FormatterOptions $options
-	 *
-	 * @return ValueFormatter
-	 */
-	protected function getInstance( FormatterOptions $options ) {
-		$decimalFormatter = new DecimalFormatter( $options );
-		$class = $this->getFormatterClass();
-		return new $class( $decimalFormatter, $options );
 	}
 
 }


### PR DESCRIPTION
Requires https://github.com/DataValues/Interfaces/pull/9 to be released as a new version.

Bug: [T92268](https://phabricator.wikimedia.org/T92268)
Bug: [T92280](https://phabricator.wikimedia.org/T92280)