### PR TITLE
Simplify regular expressions

### DIFF
--- a/src/DataValues/DecimalMath.php
+++ b/src/DataValues/DecimalMath.php
@@ -500,7 +500,7 @@ class DecimalMath {
 	 * @return string
 	 */
 	private function stripLeadingZeros( $digits ) {
-		$digits = preg_replace( '/^([-+])(0+)([0-9]+(\.|$))/', '\1\3', $digits );
+		$digits = preg_replace( '/^([-+])0+(?=\d)/', '\1', $digits );
 		return $digits;
 	}
 

--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -40,7 +40,7 @@ class DecimalValue extends DataValueObject {
 	 * Regular expression for matching decimal strings that conform to the format
 	 * described in the class level documentation of @see DecimalValue.
 	 */
-	const QUANTITY_VALUE_PATTERN = '/^[-+]([1-9][0-9]*|[0-9])(\.[0-9]+)?$/';
+	const QUANTITY_VALUE_PATTERN = '/^[-+]([1-9]\d*|\d)(\.\d+)?$/';
 
 	/**
 	 * Constructs a new DecimalValue object, representing the given value.

--- a/src/ValueParsers/BasicNumberUnlocalizer.php
+++ b/src/ValueParsers/BasicNumberUnlocalizer.php
@@ -20,7 +20,7 @@ class BasicNumberUnlocalizer implements NumberUnlocalizer {
 	 * @return string unlocalized number, in a form suitable for floatval resp. intval.
 	 */
 	public function unlocalizeNumber( $number ) {
-		return preg_replace( '/[^-+0-9.eExX]/', '', $number );
+		return preg_replace( '/[^-+\d.EX]+/i', '', $number );
 	}
 
 	/**
@@ -34,7 +34,7 @@ class BasicNumberUnlocalizer implements NumberUnlocalizer {
 	 * @return string regular expression
 	 */
 	public function getNumberRegex( $delimiter = '/' ) {
-		return '(?:[-+]\s*)?(?:[0-9,]+\.[0-9]*|\.?[0-9]+)(?:[eE][-+]?[0-9]+)?';
+		return '(?:[-+]\s*)?(?:[\d,]+\.\d*|\.?\d+)(?:[eE][-+]?\d+)?';
 	}
 
 	/**
@@ -51,7 +51,7 @@ class BasicNumberUnlocalizer implements NumberUnlocalizer {
 	public function getUnitRegex( $delimiter = '/' ) {
 		return '[a-zA-ZµåÅöÖ' . preg_quote( '°%', $delimiter ) . ']+'
 			. '(?:[' . preg_quote( '-.^/', $delimiter ) . ']?'
-			. '[a-zA-Z0-9åÅöÖ' . preg_quote( '°%²³', $delimiter ) . ']+)*';
+			. '[a-zA-Z\dåÅöÖ' . preg_quote( '°%²³', $delimiter ) . ']+)*';
 	}
 
 }

--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -102,7 +102,7 @@ class DecimalParser extends StringValueParser {
 	 * - the decimal separator is '.' (period). Comma is not used anywhere.
 	 * - leading and trailing as well as any internal whitespace is ignored
 	 * - the following characters are ignored: comma (","), apostrophe ("'").
-	 * - scientific (exponential) notation is supported using the pattern /e[-+][0-9]+/
+	 * - scientific (exponential) notation is supported using the pattern /e[-+]\d+/
 	 * - the number may start (or end) with a decimal point.
 	 * - leading zeroes are stripped, except directly before the decimal point
 	 * - trailing zeroes are stripped, except directly after the decimal point
@@ -150,7 +150,7 @@ class DecimalParser extends StringValueParser {
 	 */
 	private function normalizeDecimal( $number ) {
 		// strip fluff
-		$number = preg_replace( '/[ \r\n\t\'_,`]/u', '', $number );
+		$number = preg_replace( '/[ \r\n\t\'_,`]+/u', '', $number );
 
 		// strip leading zeros
 		$number = preg_replace( '/^([-+]?)0+([^0]|0$)/', '$1$2', $number );
@@ -162,7 +162,7 @@ class DecimalParser extends StringValueParser {
 		$number = preg_replace( '/\.$/', '', $number );
 
 		// add leading sign
-		$number = preg_replace( '/^([0-9])/', '+$1', $number );
+		$number = preg_replace( '/^(?=\d)/', '+', $number );
 
 		// make "negative" zero positive
 		$number = preg_replace( '/^-(0+(\.0+)?)$/', '+$1', $number );

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -190,7 +190,7 @@ class QuantityParserTest extends StringValueParserTest {
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'getNumberRegex' )
-			->will(  $this->returnValue( '[0-9 ]+(?:,[0-9]+)?' ) );
+			->will(  $this->returnValue( '[\d ]+(?:,\d+)?' ) );
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'getUnitRegex' )


### PR DESCRIPTION
This simplifies all regular expressions in this component, partly to increase performance (e.g. do not match parts that are not used afterwards), partly for readability (e.g. use the `\d` shortcut).