### PR TITLE
Split QuantityFormatter implementation

### DIFF
--- a/src/DataValues/DecimalMath.php
+++ b/src/DataValues/DecimalMath.php
@@ -28,7 +28,7 @@ class DecimalMath {
 	 *
 	 * @var bool
 	 */
-	protected $useBC;
+	private $useBC;
 
 	/**
 	 * @param bool|null $useBC Whether to use the bcmath library. If null,
@@ -242,7 +242,7 @@ class DecimalMath {
 	 * @throws InvalidArgumentException if $significantDigits is smaller than 0
 	 * @return string
 	 */
-	protected function roundDigits( $value, $significantDigits ) {
+	private function roundDigits( $value, $significantDigits ) {
 		if ( !is_int( $significantDigits ) ) {
 			throw new InvalidArgumentException( '$significantDigits must be an integer' );
 		}
@@ -393,7 +393,7 @@ class DecimalMath {
 	 * @param string $value
 	 * @return string
 	 */
-	protected function bumpDigits( $value ) {
+	private function bumpDigits( $value ) {
 		if ( $value === '+0' ) {
 			return '+1';
 		}
@@ -452,7 +452,7 @@ class DecimalMath {
 	 * @param string $value
 	 * @return string
 	 */
-	protected function slumpDigits( $value ) {
+	private function slumpDigits( $value ) {
 		if ( $value === '+0' ) {
 			return '-1';
 		}
@@ -499,7 +499,7 @@ class DecimalMath {
 	 *
 	 * @return string
 	 */
-	protected function stripLeadingZeros( $digits ) {
+	private function stripLeadingZeros( $digits ) {
 		$digits = preg_replace( '/^([-+])(0+)([0-9]+(\.|$))/', '\1\3', $digits );
 		return $digits;
 	}

--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -50,10 +50,10 @@ class DecimalValue extends DataValueObject {
 	 */
 	public function __construct( $value ) {
 		if ( is_int( $value ) || is_float( $value ) ) {
-			$value = self::convertToDecimal( $value );
+			$value = $this->convertToDecimal( $value );
 		}
 
-		self::assertNumberString( $value );
+		$this->assertNumberString( $value );
 
 		// make "negative" zero positive
 		$value = preg_replace( '/^-(0+(\.0+)?)$/', '+\1', $value );
@@ -68,7 +68,7 @@ class DecimalValue extends DataValueObject {
 	 *
 	 * @throws IllegalValueException
 	 */
-	protected static function assertNumberString( $number ) {
+	private function assertNumberString( $number ) {
 		if ( !is_string( $number ) ) {
 			throw new IllegalValueException( '$number must be a numeric string.' );
 		}
@@ -92,7 +92,7 @@ class DecimalValue extends DataValueObject {
 	 * @return string
 	 * @throws InvalidArgumentException
 	 */
-	protected static function convertToDecimal( $number ) {
+	private function convertToDecimal( $number ) {
 		if ( !is_int( $number ) && !is_float( $number ) ) {
 			throw new InvalidArgumentException( '$number must be an int or float.' );
 		}
@@ -119,7 +119,7 @@ class DecimalValue extends DataValueObject {
 
 		$decimal = ( ( $number >= 0.0 ) ? '+' : '-' ) . $decimal;
 
-		self::assertNumberString( $decimal );
+		$this->assertNumberString( $decimal );
 		return $decimal;
 	}
 

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -22,28 +22,28 @@ class QuantityValue extends DataValueObject {
 	 *
 	 * @var DecimalValue
 	 */
-	protected $amount;
+	private $amount;
 
 	/**
 	 * The quantity's unit identifier (use "1" for unitless quantities).
 	 *
 	 * @var string
 	 */
-	protected $unit;
+	private $unit;
 
 	/**
 	 * The quantity's upper bound
 	 *
 	 * @var DecimalValue
 	 */
-	protected $upperBound;
+	private $upperBound;
 
 	/**
 	 * The quantity's lower bound
 	 *
 	 * @var DecimalValue
 	 */
-	protected $lowerBound;
+	private $lowerBound;
 
 	/**
 	 * Constructs a new QuantityValue object, representing the given value.

--- a/src/ValueFormatters/DecimalFormatter.php
+++ b/src/ValueFormatters/DecimalFormatter.php
@@ -25,7 +25,7 @@ class DecimalFormatter extends ValueFormatterBase {
 	/**
 	 * @var NumberLocalizer
 	 */
-	protected $localizer;
+	private $localizer;
 
 	/**
 	 * @param FormatterOptions|null $options
@@ -40,18 +40,18 @@ class DecimalFormatter extends ValueFormatterBase {
 	}
 
 	/**
-	 * Formats a QuantityValue data value
+	 * @see ValueFormatter::format
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $dataValue value to format
+	 * @param DecimalValue $dataValue
 	 *
-	 * @return string
 	 * @throws InvalidArgumentException
+	 * @return string Text
 	 */
 	public function format( $dataValue ) {
 		if ( !( $dataValue instanceof DecimalValue ) ) {
-			throw new InvalidArgumentException( 'DataValue is not a DecimalValue.' );
+			throw new InvalidArgumentException( 'Data value type mismatch. Expected a DecimalValue.' );
 		}
 
 		// TODO: Implement optional rounding/padding

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -3,6 +3,7 @@
 namespace ValueFormatters;
 
 use DataValues\DecimalMath;
+use DataValues\DecimalValue;
 use DataValues\QuantityValue;
 use InvalidArgumentException;
 
@@ -13,6 +14,7 @@ use InvalidArgumentException;
  *
  * @licence GNU GPL v2+
  * @author Daniel Kinzler
+ * @author Thiemo Mättig
  */
 class QuantityFormatter extends ValueFormatterBase {
 
@@ -46,12 +48,12 @@ class QuantityFormatter extends ValueFormatterBase {
 	/**
 	 * @var DecimalMath
 	 */
-	protected $decimalMath;
+	private $decimalMath;
 
 	/**
 	 * @var DecimalFormatter
 	 */
-	protected $decimalFormatter;
+	private $decimalFormatter;
 
 	/**
 	 * @var QuantityUnitFormatter
@@ -82,6 +84,50 @@ class QuantityFormatter extends ValueFormatterBase {
 	}
 
 	/**
+	 * @see ValueFormatter::format
+	 *
+	 * @since 0.1
+	 *
+	 * @param QuantityValue $value
+	 *
+	 * @throws InvalidArgumentException
+	 * @return string Text
+	 */
+	public function format( $value ) {
+		if ( !( $value instanceof QuantityValue ) ) {
+			throw new InvalidArgumentException( 'Data value type mismatch. Expected a QuantityValue.' );
+		}
+
+		return $this->formatQuantityValue( $value );
+	}
+
+	/**
+	 * @param QuantityValue $quantity
+	 *
+	 * @return string Text
+	 */
+	private function formatQuantityValue( QuantityValue $quantity ) {
+		$roundingExponent = $this->getRoundingExponent( $quantity );
+
+		$amount = $quantity->getAmount();
+		$roundedAmount = $this->decimalMath->roundToExponent( $amount, $roundingExponent );
+		$formatted = $this->decimalFormatter->format( $roundedAmount );
+
+		$margin = $this->formatMargin( $quantity->getUncertaintyMargin(), $roundingExponent );
+		if ( $margin !== null ) {
+			// TODO: use localizable pattern for constructing the output.
+			$formatted .= '±' . $margin;
+		}
+
+		$unit = $quantity->getUnit();
+		if ( $this->options->getOption( self::OPT_APPLY_UNIT ) && $unit !== '1' && $unit !== '' ) {
+			$formatted = $this->unitFormatter->applyUnit( $unit, $formatted );
+		}
+
+		return $formatted;
+	}
+
+	/**
 	 * Returns the rounding exponent based on the given $quantity
 	 * and the @see QuantityFormatter::OPT_APPLY_ROUNDING option.
 	 *
@@ -89,7 +135,7 @@ class QuantityFormatter extends ValueFormatterBase {
 	 *
 	 * @return int
 	 */
-	protected function getRoundingExponent( QuantityValue $quantity ) {
+	private function getRoundingExponent( QuantityValue $quantity ) {
 		if ( $this->options->getOption( self::OPT_APPLY_ROUNDING ) === true ) {
 			// round to the order of uncertainty
 			return $quantity->getOrderOfUncertainty();
@@ -102,53 +148,22 @@ class QuantityFormatter extends ValueFormatterBase {
 	}
 
 	/**
-	 * Formats a QuantityValue data value
+	 * @param DecimalValue $margin
+	 * @param int $roundingExponent
 	 *
-	 * @since 0.1
-	 *
-	 * @param mixed $dataValue value to format
-	 *
-	 * @return string
-	 * @throws InvalidArgumentException
+	 * @return string|null Text
 	 */
-	public function format( $dataValue ) {
-		if ( !( $dataValue instanceof QuantityValue ) ) {
-			throw new InvalidArgumentException( 'DataValue is not a QuantityValue.' );
-		}
-
-		$roundingExponent = $this->getRoundingExponent( $dataValue );
-
-		$amountValue = $dataValue->getAmount();
-		$amountValue = $this->decimalMath->roundToExponent( $amountValue, $roundingExponent );
-		$amount = $this->decimalFormatter->format( $amountValue );
-
-		$unit = $dataValue->getUnit();
-
-		$margin = '';
-
+	private function formatMargin( DecimalValue $margin, $roundingExponent ) {
 		if ( $this->options->getOption( self::OPT_SHOW_UNCERTAINTY_MARGIN ) ) {
-
 			// TODO: never round to 0! See bug #56892
-			$marginValue = $dataValue->getUncertaintyMargin();
-			$marginValue = $this->decimalMath->roundToExponent( $marginValue, $roundingExponent );
+			$roundedMargin = $this->decimalMath->roundToExponent( $margin, $roundingExponent );
 
-			if ( !$marginValue->isZero() ) {
-				$margin = $this->decimalFormatter->format( $marginValue );
+			if ( !$roundedMargin->isZero() ) {
+				return $this->decimalFormatter->format( $roundedMargin );
 			}
 		}
 
-		$quantity = $amount;
-
-		if ( $margin !== '' ) {
-			//TODO: use localizable pattern for constructing the output.
-			$quantity .= '±' . $margin;
-		}
-
-		if ( $this->options->getOption( self::OPT_APPLY_UNIT ) && $unit !== '1' && $unit !== '' ) {
-			$quantity = $this->unitFormatter->applyUnit( $unit, $quantity );
-		}
-
-		return $quantity;
+		return null;
 	}
 
 }


### PR DESCRIPTION
This fixes all problems I found while reviewing #31.
* The about 30 line function `QuantityFormatter::format` is now split into three functions.
* Composition via the `ValueFormatter` interface, not via the implementation.
* Much more specific type hints on all `format` functions.
* Private by default for everything that's currently protected.