### PR TITLE
Release 0.5.0

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_NUMBER_VERSION', '0.4.1' );
+define( 'DATAVALUES_NUMBER_VERSION', '0.5.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ DataValues Number has been written by Daniel Kinzler, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.5.0 (2015-06-11)
+
+#### Breaking changes
+* `QuantityFormatter` constructor parameters changed in an incompatible way
+
+#### Additions
+* Added `QuantityUnitFormatter` interface
+* Added `BasicQuantityUnitFormatter`
+* Added `QuantityFormatter::OPT_APPLY_UNIT` option
+* Added `QuantityParser::OPT_UNIT` option
+* Added `DecimalParser::applyDecimalExponent`
+* Added `DecimalParser::splitDecimalExponent`
+
+#### Other changes
+* `QuantityParser` now correctly detect precision for scientific notation
+* Made constructor parameters optional in `DecimalFormatter` and `QuantityFormatter`
+* Updated DataValues Interfaces dependency to 0.1.5
+
 ### 0.4.1 (2014-10-09)
 
 * The component can now be installed together with DataValues 1.x

--- a/src/ValueFormatters/BasicQuantityUnitFormatter.php
+++ b/src/ValueFormatters/BasicQuantityUnitFormatter.php
@@ -3,7 +3,9 @@
 namespace ValueFormatters;
 
 /**
- * A basic QuantityUnitFormatter.
+ * A basic QuantityUnitFormatter that just appends non-default units to the number string.
+ *
+ * @since 0.5
  *
  * @licence GNU GPL v2+
  * @author Daniel Kinzler
@@ -24,9 +26,9 @@ class BasicQuantityUnitFormatter implements QuantityUnitFormatter {
 	public function applyUnit( $unit, $numberText ) {
 		if ( $unit === '1' || $unit === '' ) {
 			return $numberText;
-		} else {
-			return $numberText . $unit;
 		}
+
+		return $numberText . $unit;
 	}
 
 }

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -42,6 +42,8 @@ class QuantityFormatter extends ValueFormatterBase {
 	/**
 	 * Option key controlling whether the quantity's unit of measurement should be included
 	 * in the output.
+	 *
+	 * @since 0.5
 	 */
 	const OPT_APPLY_UNIT = 'applyUnit';
 

--- a/src/ValueFormatters/QuantityUnitFormatter.php
+++ b/src/ValueFormatters/QuantityUnitFormatter.php
@@ -5,6 +5,8 @@ namespace ValueFormatters;
 /**
  * Interface defining a service for formatting a quantity's unit.
  *
+ * @since 0.5
+ *
  * @licence GNU GPL v2+
  * @author Daniel Kinzler
  */

--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -54,6 +54,8 @@ class DecimalParser extends StringValueParser {
 	/**
 	 * Splits the exponent from the scientific notation of a decimal number.
 	 *
+	 * @since 0.5
+	 *
 	 * @example splitDecimalExponent( '1.2' )  is  array( '1.2', 0 )
 	 * @example splitDecimalExponent( '1.2e3' )  is  array( '1.2', 3 )
 	 * @example splitDecimalExponent( '1.2e-2' )  is  array( '1.2', -2 )
@@ -76,6 +78,8 @@ class DecimalParser extends StringValueParser {
 	/**
 	 * Applies a decimal exponent, by shifting the decimal point in the decimal string
 	 * representation of the value.
+	 *
+	 * @since 0.5
 	 *
 	 * @example applyDecimalExponent( new DecimalValue( '1.2' ), 0 )  is  new DecimalValue( '1.2' )
 	 * @example applyDecimalExponent( new DecimalValue( '1.2' ), 3 )  is  new DecimalValue( '1200' )

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -23,6 +23,8 @@ class QuantityParser extends StringValueParser {
 	/**
 	 * The unit of the value to parse. If this option is given, it's illegal to also specify
 	 * a unit in the input string.
+	 *
+	 * @since 0.5
 	 */
 	const OPT_UNIT = 'unit';
 


### PR DESCRIPTION
Please have a look at https://github.com/DataValues/Number/compare/0.4.1...master and check that I did not forget anything.

~~Please note that I think the actual 0.5.0 release is blocked because of [T95425](https://phabricator.wikimedia.org/T95425).~~ Ok, the issue already existed in 0.4 (see https://github.com/DataValues/Number/blob/0.4.1/tests/ValueFormatters/QuantityFormatterTest.php#L62), so this can't be a reason to block 0.5.