### PR TITLE
Remove not needed PHPDoc tags from tests

### DIFF
--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -19,8 +19,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider bumpProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testBump( DecimalValue $value, $expected ) {
 		$math = new DecimalMath();
@@ -51,8 +49,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider slumpProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testSlump( DecimalValue $value, $expected ) {
 		$math = new DecimalMath();
@@ -214,8 +210,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider roundToDigitProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testRoundToDigit( DecimalValue $value, $digits, $expected ) {
 		$math = new DecimalMath();
@@ -292,8 +286,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider getPositionForExponentProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetPositionForExponent( $exponent, DecimalValue $decimal, $expected ) {
 		$math = new DecimalMath();
@@ -314,10 +306,9 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 		return $argLists;
 	}
-		/**
+
+	/**
 	 * @dataProvider roundToExponentProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testRoundToExponent( DecimalValue $value, $digits, $expected ) {
 		$math = new DecimalMath();
@@ -388,10 +379,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider shiftProvider
-	 *
-	 * @param DecimalValue $value
-	 * @param $exponent
-	 * @param $expected
 	 */
 	public function testShift( DecimalValue $value, $exponent, $expected ) {
 		$math = new DecimalMath();

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -19,8 +19,6 @@ class DecimalValueTest extends DataValueTest {
 	/**
 	 * @see DataValueTest::getClass
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getClass() {
@@ -77,8 +75,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider compareProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testCompare( DecimalValue $a, DecimalValue $b, $expected ) {
 		$actual = $a->compare( $b );
@@ -118,8 +114,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider getSignProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetSign( DecimalValue $value, $expected ) {
 		$actual = $value->getSign();
@@ -140,8 +134,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider getValueProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetValue( DecimalValue $value, $expected ) {
 		$actual = $value->getValue();
@@ -173,8 +165,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider getValueFloatProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetValueFloat( DecimalValue $value, $expected ) {
 		$actual = $value->getValueFloat();
@@ -203,8 +193,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider getGetIntegerPartProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetIntegerPart( DecimalValue $value, $expected ) {
 		$actual = $value->getIntegerPart();
@@ -225,8 +213,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider getGetIntegerPartProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testGetFractionalPart( DecimalValue $value, $expected ) {
 		$actual = $value->getIntegerPart();
@@ -246,8 +232,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider computeComplementProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testComputeComplement( DecimalValue $value, $expected ) {
 		$complement = $value->computeComplement();
@@ -269,8 +253,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider computeComputeAbsolute
-	 *
-	 * @since 0.1
 	 */
 	public function testComputeAbsolute( DecimalValue $value, $expected ) {
 		$absolute = $value->computeAbsolute();
@@ -294,8 +276,6 @@ class DecimalValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider isZeroProvider
-	 *
-	 * @since 0.1
 	 */
 	public function testIsZero( DecimalValue $value, $expected ) {
 		$actual = $value->isZero();

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -19,8 +19,6 @@ class QuantityValueTest extends DataValueTest {
 	/**
 	 * @see DataValueTest::getClass
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getClass() {
@@ -51,8 +49,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param QuantityValue $quantity
-	 * @param array $arguments
 	 */
 	public function testGetValue( QuantityValue $quantity, array $arguments ) {
 		$this->assertInstanceOf( $this->getClass(), $quantity->getValue() );
@@ -60,8 +56,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param QuantityValue $quantity
-	 * @param array $arguments
 	 */
 	public function testGetAmount( QuantityValue $quantity, array $arguments ) {
 		$this->assertEquals( $arguments[0], $quantity->getAmount() );
@@ -69,8 +63,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param QuantityValue $quantity
-	 * @param array $arguments
 	 */
 	public function testGetUnit( QuantityValue $quantity, array $arguments ) {
 		$this->assertEquals( $arguments[1], $quantity->getUnit() );
@@ -78,8 +70,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param QuantityValue $quantity
-	 * @param array $arguments
 	 */
 	public function testGetUpperBound( QuantityValue $quantity, array $arguments ) {
 		$this->assertEquals( $arguments[2], $quantity->getUpperBound() );
@@ -87,8 +77,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param QuantityValue $quantity
-	 * @param array $arguments
 	 */
 	public function testGetLowerBound( QuantityValue $quantity, array $arguments ) {
 		$this->assertEquals( $arguments[3], $quantity->getLowerBound() );
@@ -96,12 +84,6 @@ class QuantityValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider newFromNumberProvider
-	 *
-	 * @param $amount
-	 * @param $unit
-	 * @param $upperBound
-	 * @param $lowerBound
-	 * @param QuantityValue $expected
 	 */
 	public function testNewFromNumber( $amount, $unit, $upperBound, $lowerBound, QuantityValue $expected ) {
 		$quantity = QuantityValue::newFromNumber( $amount, $unit, $upperBound, $lowerBound );

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -37,10 +37,6 @@ class DecimalFormatterTest extends ValueFormatterTestBase {
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validProvider() {
 		$optionsForceSign = new FormatterOptions( array(

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -41,10 +41,6 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validProvider() {
 		$noMargin = new FormatterOptions( array(


### PR DESCRIPTION
* `@since` is helpful in actual classes, but pretty pointless in tests.
* `@param` docs for `@dataProvider`s usually do not add much information, especially if they are incomplete.