### PR TITLE
Compatible with Interfaces 0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "^0.1.5",
+		"data-values/interfaces": "~0.2.0|~0.1.5",
 		"data-values/common": "~0.2"
 	},
 	"autoload": {


### PR DESCRIPTION
This component already is compatible with both DataValues Interfaces >=0.1.5 and 2.0.0. All relevant changes between these two versions are implemented in a compatible way in this component.

Please also merge the same patch in https://github.com/DataValues/Geo/pull/50.