### PR TITLE
Add $quantityWithUnitFormat parameter to Quantity[Html]Formatter

### DIFF
--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -63,16 +63,26 @@ class QuantityFormatter extends ValueFormatterBase {
 	private $vocabularyUriFormatter;
 
 	/**
+	 * @var string
+	 */
+	private $quantityWithUnitFormat;
+
+	/**
 	 * @since 0.6
 	 *
 	 * @param FormatterOptions|null $options
 	 * @param DecimalFormatter|null $decimalFormatter
 	 * @param ValueFormatter|null $vocabularyUriFormatter
+	 * @param string|null $quantityWithUnitFormat Format string with two placeholders, $1 for the
+	 * number and $2 for the unit. Warning, this must be under the control of the application, not
+	 * under the control of the user, because it allows HTML injections in subclasses that return
+	 * HTML.
 	 */
 	public function __construct(
 		FormatterOptions $options = null,
 		DecimalFormatter $decimalFormatter = null,
-		ValueFormatter $vocabularyUriFormatter = null
+		ValueFormatter $vocabularyUriFormatter = null,
+		$quantityWithUnitFormat = null
 	) {
 		parent::__construct( $options );
 
@@ -82,9 +92,19 @@ class QuantityFormatter extends ValueFormatterBase {
 
 		$this->decimalFormatter = $decimalFormatter ?: new DecimalFormatter( $this->options );
 		$this->vocabularyUriFormatter = $vocabularyUriFormatter;
+		$this->quantityWithUnitFormat = $quantityWithUnitFormat ?: '$1 $2';
 
 		// plain composition should be sufficient
 		$this->decimalMath = new DecimalMath();
+	}
+
+	/**
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	final protected function getQuantityWithUnitFormat() {
+		return $this->quantityWithUnitFormat;
 	}
 
 	/**
@@ -117,8 +137,13 @@ class QuantityFormatter extends ValueFormatterBase {
 		$unit = $this->formatUnit( $quantity->getUnit() );
 
 		if ( $unit !== null ) {
-			// TODO: localizable pattern for placement (before/after, separator)
-			$formatted .= ' ' . $unit;
+			$formatted = strtr(
+				$this->getQuantityWithUnitFormat(),
+				array(
+					'$1' => $formatted,
+					'$2' => $unit
+				)
+			);
 		}
 
 		return $formatted;

--- a/src/ValueFormatters/QuantityHtmlFormatter.php
+++ b/src/ValueFormatters/QuantityHtmlFormatter.php
@@ -15,22 +15,33 @@ use DataValues\QuantityValue;
 class QuantityHtmlFormatter extends QuantityFormatter {
 
 	/**
-	 * @see QuantityFormatter::formatQuantityValue
+	 * @see QuantityFormatter::formatNumber
 	 *
 	 * @param QuantityValue $quantity
 	 *
 	 * @return string HTML
 	 */
-	protected function formatQuantityValue( QuantityValue $quantity ) {
-		$html = htmlspecialchars( $this->formatNumber( $quantity ) );
-		$unit = $this->formatUnit( $quantity->getUnit() );
+	protected function formatNumber( QuantityValue $quantity ) {
+		$formatted = parent::formatNumber( $quantity );
 
-		if ( $unit !== null ) {
-			// TODO: localizable pattern for placement (before/after, separator)
-			$html .= ' <span class="wb-unit">' . htmlspecialchars( $unit ) . '</span>';
+		return htmlspecialchars( $formatted );
+	}
+
+	/**
+	 * @see QuantityFormatter::formatUnit
+	 *
+	 * @param string $unit URI
+	 *
+	 * @return string|null HTML
+	 */
+	protected function formatUnit( $unit ) {
+		$formatted = parent::formatUnit( $unit );
+
+		if ( $formatted === null ) {
+			return null;
 		}
 
-		return $html;
+		return '<span class="wb-unit">' . htmlspecialchars( $formatted ) . '</span>';
 	}
 
 }

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -33,6 +33,19 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 	 * @return QuantityFormatter
 	 */
 	protected function getInstance( FormatterOptions $options = null ) {
+		return $this->getQuantityFormatter( $options );
+	}
+
+	/**
+	 * @param FormatterOptions|null $options
+	 * @param string|null $quantityWithUnitFormat
+	 *
+	 * @return QuantityFormatter
+	 */
+	private function getQuantityFormatter(
+		FormatterOptions $options = null,
+		$quantityWithUnitFormat = null
+	) {
 		$vocabularyUriFormatter = $this->getMock( 'ValueFormatters\ValueFormatter' );
 		$vocabularyUriFormatter->expects( $this->any() )
 			->method( 'format' )
@@ -43,7 +56,8 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 		return new QuantityFormatter(
 			$options,
 			new DecimalFormatter( $options ),
-			$vocabularyUriFormatter
+			$vocabularyUriFormatter,
+			$quantityWithUnitFormat
 		);
 	}
 
@@ -101,6 +115,13 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 
 			'+3.125/fs' => array( QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '+3.13', $forceSign ),
 		);
+	}
+
+	public function testFormatWithFormatString() {
+		$formatter = $this->getQuantityFormatter( null, '<$2>$1' );
+		$value = QuantityValue::newFromNumber( '+5', 'USD' );
+		$formatted = $formatter->format( $value );
+		$this->assertSame( '<USD>5', $formatted );
 	}
 
 }

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -36,12 +36,14 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 	/**
 	 * @param FormatterOptions|null $options
 	 * @param DecimalFormatter|null $decimalFormatter
+	 * @param string|null $quantityWithUnitFormat
 	 *
 	 * @return QuantityHtmlFormatter
 	 */
 	private function getQuantityHtmlFormatter(
 		FormatterOptions $options = null,
-		DecimalFormatter $decimalFormatter = null
+		DecimalFormatter $decimalFormatter = null,
+		$quantityWithUnitFormat = null
 	) {
 		$vocabularyUriFormatter = $this->getMock( 'ValueFormatters\ValueFormatter' );
 		$vocabularyUriFormatter->expects( $this->any() )
@@ -53,7 +55,8 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 		return new QuantityHtmlFormatter(
 			$options,
 			$decimalFormatter,
-			$vocabularyUriFormatter
+			$vocabularyUriFormatter,
+			$quantityWithUnitFormat
 		);
 	}
 
@@ -75,6 +78,13 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 				'2 <span class="wb-unit">&lt;b&gt;injection&lt;/b&gt;</span>'
 			),
 		);
+	}
+
+	public function testFormatWithFormatString() {
+		$formatter = $this->getQuantityHtmlFormatter( null, null, '$2&thinsp;$1' );
+		$value = QuantityValue::newFromNumber( '+5', 'USD' );
+		$formatted = $formatter->format( $value );
+		$this->assertSame( '<span class="wb-unit">USD</span>&thinsp;5', $formatted );
 	}
 
 	/**


### PR DESCRIPTION
The QuantityFormatter constructor does have a breaking change anyway. I'm reordering the parameters so that options are first, then the two formatters for the number and the unit, then the format string to combine the two.

[Bug: T111186](http://phabricator.wikimedia.org/T111186)