### PR TITLE
Better constructor order for Quantity[Html]Formatter

### DIFF
--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -63,14 +63,16 @@ class QuantityFormatter extends ValueFormatterBase {
 	private $vocabularyUriFormatter;
 
 	/**
+	 * @since 0.6
+	 *
+	 * @param FormatterOptions|null $options
 	 * @param DecimalFormatter|null $decimalFormatter
 	 * @param ValueFormatter|null $vocabularyUriFormatter
-	 * @param FormatterOptions|null $options
 	 */
 	public function __construct(
+		FormatterOptions $options = null,
 		DecimalFormatter $decimalFormatter = null,
-		ValueFormatter $vocabularyUriFormatter = null,
-		FormatterOptions $options = null
+		ValueFormatter $vocabularyUriFormatter = null
 	) {
 		parent::__construct( $options );
 

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -33,8 +33,6 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 	 * @return QuantityFormatter
 	 */
 	protected function getInstance( FormatterOptions $options = null ) {
-		$decimalFormatter = new DecimalFormatter( $options );
-
 		$vocabularyUriFormatter = $this->getMock( 'ValueFormatters\ValueFormatter' );
 		$vocabularyUriFormatter->expects( $this->any() )
 			->method( 'format' )
@@ -42,7 +40,11 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 				return $unit === '1' ? null : $unit;
 			} ) );
 
-		return new QuantityFormatter( $decimalFormatter, $vocabularyUriFormatter, $options );
+		return new QuantityFormatter(
+			$options,
+			new DecimalFormatter( $options ),
+			$vocabularyUriFormatter
+		);
 	}
 
 	/**

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -30,18 +30,18 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 	 * @return QuantityHtmlFormatter
 	 */
 	protected function getInstance( FormatterOptions $options = null ) {
-		return $this->getQuantityHtmlFormatter( null, $options );
+		return $this->getQuantityHtmlFormatter( $options );
 	}
 
 	/**
-	 * @param DecimalFormatter|null $decimalFormatter
 	 * @param FormatterOptions|null $options
+	 * @param DecimalFormatter|null $decimalFormatter
 	 *
 	 * @return QuantityHtmlFormatter
 	 */
 	private function getQuantityHtmlFormatter(
-		DecimalFormatter $decimalFormatter = null,
-		FormatterOptions $options = null
+		FormatterOptions $options = null,
+		DecimalFormatter $decimalFormatter = null
 	) {
 		$vocabularyUriFormatter = $this->getMock( 'ValueFormatters\ValueFormatter' );
 		$vocabularyUriFormatter->expects( $this->any() )
@@ -50,7 +50,11 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 				return $unit === '1' ? null : $unit;
 			} ) );
 
-		return new QuantityHtmlFormatter( $decimalFormatter, $vocabularyUriFormatter, $options );
+		return new QuantityHtmlFormatter(
+			$options,
+			$decimalFormatter,
+			$vocabularyUriFormatter
+		);
 	}
 
 	/**
@@ -86,7 +90,7 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 			->method( 'format' )
 			->will( $this->returnValue( '<b>+2</b>' ) );
 
-		$formatter = $this->getQuantityHtmlFormatter( $decimalFormatter, $options );
+		$formatter = $this->getQuantityHtmlFormatter( $options, $decimalFormatter );
 		$formatted = $formatter->format( QuantityValue::newFromNumber( '+2', $unit ) );
 		$this->assertSame( $expected, $formatted );
 	}


### PR DESCRIPTION
This is split from #44 to make it focused on the actual change it is about. Please note that both constructors already changed in #41. This already is a breaking change and needs a 0.6 release. This patch does not make this situation worse, it makes it better by moving the (basically non-optional) options parameter to the front, followed by the two sub-formatters, in #44 followed by the pattern that concatenates both.

[Bug: T111186](http://phabricator.wikimedia.org/T111186)