### PR TITLE
Revert QuantityParserTest cases with units

### DIFF
--- a/src/ValueParsers/BasicNumberUnlocalizer.php
+++ b/src/ValueParsers/BasicNumberUnlocalizer.php
@@ -40,13 +40,9 @@ class BasicNumberUnlocalizer implements NumberUnlocalizer {
 	/**
 	 * @see NumberUnlocalizer::getUnitRegex
 	 *
-	 * This implementation returns an expression that will match any sequence
-	 * of latin characters in addition to a variety of characters commonly
-	 * used in unit identifiers, such as µ (mu).
+	 * @param string $delimiter Unused.
 	 *
-	 * @param string $delimiter The regex delimiter, used for escaping.
-	 *
-	 * @return string regular expression
+	 * @return string An empty string.
 	 */
 	public function getUnitRegex( $delimiter = '/' ) {
 		// TODO: Discuss and specify what QuantityParser should accept.


### PR DESCRIPTION
This reverts the changes in the QuantityParserTest class we did in #46. Please use this diff: https://github.com/DataValues/Number/compare/de7ca6...revert-46-dumpUnitParser. Note that the relevant changes from #46 are still there, but the QuantityParserTest test cases are all unchanged. Instead I'm introducing a mock that makes all these tests cases still succeed. This makes the two tests independent, just as it should be.