### PR TITLE
Compatible with DataValues Common 0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0|~0.1.5",
-		"data-values/common": "~0.2"
+		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"autoload": {
 		"files" : [

--- a/src/ValueFormatters/DecimalFormatter.php
+++ b/src/ValueFormatters/DecimalFormatter.php
@@ -42,8 +42,6 @@ class DecimalFormatter extends ValueFormatterBase {
 	/**
 	 * @see ValueFormatter::format
 	 *
-	 * @since 0.1
-	 *
 	 * @param DecimalValue $dataValue
 	 *
 	 * @throws InvalidArgumentException

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -110,8 +110,6 @@ class QuantityFormatter extends ValueFormatterBase {
 	/**
 	 * @see ValueFormatter::format
 	 *
-	 * @since 0.1
-	 *
 	 * @param QuantityValue $value
 	 *
 	 * @throws InvalidArgumentException

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -80,7 +80,7 @@ class DecimalParserTest extends StringValueParserTest {
 	}
 
 	/**
-	 * @see ValueParserTestBase::invalidInputProvider
+	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -139,7 +139,7 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	/**
-	 * @see ValueParserTestBase::invalidInputProvider
+	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();


### PR DESCRIPTION
* This component is compatible with Common 0.3.x. [The breaking changes between Common 0.2.x and 0.3.x](https://github.com/DataValues/Common/compare/0.2.3...0.3.0) are not used here.
* I'm removing a few `@since` tags from methods that implement an abstract base class and do not add information.

Also see:
* https://github.com/DataValues/Geo/pull/58
* https://github.com/wmde/WikibaseDataModelSerialization/pull/183
* https://github.com/wmde/WikibaseInternalSerialization/pull/90