### PR TITLE
[WIP] Allow QuantityValue::upper/lowerBounds to be null

### DIFF
--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -191,13 +191,13 @@ class QuantityFormatter extends ValueFormatterBase {
 	}
 
 	/**
-	 * @param DecimalValue $margin
+	 * @param DecimalValue|null $margin
 	 * @param int $roundingExponent
 	 *
 	 * @return string|null Text
 	 */
-	private function formatMargin( DecimalValue $margin, $roundingExponent ) {
-		if ( $this->options->getOption( self::OPT_SHOW_UNCERTAINTY_MARGIN ) ) {
+	private function formatMargin( DecimalValue $margin = null, $roundingExponent ) {
+		if ( $margin !== null && $this->options->getOption( self::OPT_SHOW_UNCERTAINTY_MARGIN ) ) {
 			// TODO: never round to 0! See bug #56892
 			$roundedMargin = $this->decimalMath->roundToExponent( $margin, $roundingExponent );
 

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -26,60 +26,108 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = array();
-
-		$argLists[] = array( new DecimalValue( '+42' ), '1', new DecimalValue( '+42' ), new DecimalValue( '+42' ) );
-		$argLists[] = array( new DecimalValue( '+0.01' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '+0.0001' ) );
-		$argLists[] = array( new DecimalValue( '-0.5' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '-0.7' ) );
-
-		return $argLists;
+		return array(
+			'Integer' => array(
+				new DecimalValue( '+42' ),
+				'1',
+				new DecimalValue( '+42' ),
+				new DecimalValue( '+42' )
+			),
+			'Float' => array(
+				new DecimalValue( '+0.01' ),
+				'1',
+				new DecimalValue( '+0.02' ),
+				new DecimalValue( '+0.0001' )
+			),
+			'Negative' => array(
+				new DecimalValue( '-0.5' ),
+				'1',
+				new DecimalValue( '+0.02' ),
+				new DecimalValue( '-0.7' )
+			),
+			'Unknown uncertainty' => array(
+				new DecimalValue( '+1' ),
+				'1',
+				null,
+				null
+			),
+		);
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = array();
-
-		$argLists[] = array( new DecimalValue( '+0' ), '', new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
-		$argLists[] = array( new DecimalValue( '+0' ), 1, new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
-
-		$argLists[] = array( new DecimalValue( '+0' ), '1', new DecimalValue( '-0.001' ), new DecimalValue( '-1' ) );
-		$argLists[] = array( new DecimalValue( '+0' ), '1', new DecimalValue( '+1' ), new DecimalValue( '+0.001' ) );
-
-		return $argLists;
+		return array(
+			'Empty unit' => array(
+				new DecimalValue( '+0' ),
+				'',
+				new DecimalValue( '+0' ),
+				new DecimalValue( '+0' )
+			),
+			'Integer unit' => array(
+				new DecimalValue( '+0' ),
+				1,
+				new DecimalValue( '+0' ),
+				new DecimalValue( '+0' )
+			),
+			'Upper below amount' => array(
+				new DecimalValue( '+0' ),
+				'1',
+				new DecimalValue( '-0.001' ),
+				new DecimalValue( '-1' )
+			),
+			'Lower above amount' => array(
+				new DecimalValue( '+0' ),
+				'1',
+				new DecimalValue( '+1' ),
+				new DecimalValue( '+0.001' )
+			),
+			'Upper without lower' => array(
+				new DecimalValue( '+1' ),
+				'1',
+				new DecimalValue( '+1' ),
+				null
+			),
+			'Lower without upper' => array(
+				new DecimalValue( '+1' ),
+				'1',
+				null,
+				new DecimalValue( '+1' )
+			),
+		);
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetValue( QuantityValue $quantity, array $arguments ) {
-		$this->assertInstanceOf( $this->getClass(), $quantity->getValue() );
+		$this->assertSame( $quantity, $quantity->getValue() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetAmount( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[0], $quantity->getAmount() );
+		$this->assertSame( $arguments[0], $quantity->getAmount() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetUnit( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[1], $quantity->getUnit() );
+		$this->assertSame( $arguments[1], $quantity->getUnit() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetUpperBound( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[2], $quantity->getUpperBound() );
+		$this->assertSame( $arguments[2], $quantity->getUpperBound() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetLowerBound( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[3], $quantity->getLowerBound() );
+		$this->assertSame( $arguments[3], $quantity->getLowerBound() );
 	}
 
 	/**
@@ -89,19 +137,25 @@ class QuantityValueTest extends DataValueTest {
 		$quantity = QuantityValue::newFromNumber( $amount, $unit, $upperBound, $lowerBound );
 
 		$this->assertEquals( $expected->getAmount()->getValue(), $quantity->getAmount()->getValue() );
-		$this->assertEquals( $expected->getUpperBound()->getValue(), $quantity->getUpperBound()->getValue() );
-		$this->assertEquals( $expected->getLowerBound()->getValue(), $quantity->getLowerBound()->getValue() );
+		$this->assertEquals(
+			$expected->getUpperBound() ? $expected->getUpperBound()->getValue() : null,
+			$quantity->getUpperBound() ? $quantity->getUpperBound()->getValue() : null
+		);
+		$this->assertEquals(
+			$expected->getLowerBound() ? $expected->getLowerBound()->getValue() : null,
+			$quantity->getLowerBound() ? $quantity->getLowerBound()->getValue() : null
+		);
 	}
 
 	public function newFromNumberProvider() {
 		return array(
 			array(
 				42, '1', null, null,
-				new QuantityValue( new DecimalValue( '+42' ), '1', new DecimalValue( '+42' ), new DecimalValue( '+42' ) )
+				new QuantityValue( new DecimalValue( '+42' ), '1' )
 			),
 			array(
 				-0.05, '1', null, null,
-				new QuantityValue( new DecimalValue( '-0.05' ), '1', new DecimalValue( '-0.05' ), new DecimalValue( '-0.05' ) )
+				new QuantityValue( new DecimalValue( '-0.05' ), '1' )
 			),
 			array(
 				0, 'm', 0.5, -0.5,
@@ -109,7 +163,7 @@ class QuantityValueTest extends DataValueTest {
 			),
 			array(
 				'+23', '1', null, null,
-				new QuantityValue( new DecimalValue( '+23' ), '1', new DecimalValue( '+23' ), new DecimalValue( '+23' ) )
+				new QuantityValue( new DecimalValue( '+23' ), '1' )
 			),
 			array(
 				'+42', '1', '+43', '+41',
@@ -150,31 +204,30 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetSortKey( QuantityValue $quantity ) {
-		$this->assertEquals( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
+		$this->assertSame( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
 	}
 
 	/**
 	 * @dataProvider getUncertaintyProvider
 	 */
 	public function testGetUncertainty( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getUncertainty();
-
-		// floats are wonkey, accept small differences here
-		$this->assertTrue( abs( $actual - $expected ) < 0.000000001, "expected $expected, got $actual" );
+		$this->assertSame( $expected, $quantity->getUncertainty() );
 	}
 
 	public function getUncertaintyProvider() {
 		return array(
-			array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0 ),
+			array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0.0 ),
 
-			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2 ),
+			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2.0 ),
 			array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), 0.02 ),
-			array( QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2 ),
+			array( QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2.0 ),
 			array( QuantityValue::newFromNumber( '+100.0', '1', '+100.1', '+99.9' ), 0.2 ),
 			array( QuantityValue::newFromNumber( '+12.34', '1', '+12.35', '+12.33' ), 0.02 ),
 
 			array( QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), 0.8 ),
 			array( QuantityValue::newFromNumber( '+7.3', '1', '+7.7', '+5.2' ), 2.5 ),
+
+			'Unknown uncertainty' => array( QuantityValue::newFromNumber( '+0' ), null ),
 		);
 	}
 
@@ -182,9 +235,11 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider getUncertaintyMarginProvider
 	 */
 	public function testGetUncertaintyMargin( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getUncertaintyMargin();
-
-		$this->assertEquals( $expected, $actual->getValue() );
+		if ( $expected === null ) {
+			$this->assertNull( $quantity->getUncertaintyMargin() );
+		} else {
+			$this->assertSame( $expected, $quantity->getUncertaintyMargin()->getValue() );
+		}
 	}
 
 	public function getUncertaintyMarginProvider() {
@@ -195,8 +250,10 @@ class QuantityValueTest extends DataValueTest {
 			array( QuantityValue::newFromNumber( '-1', '1', '-1', '-1' ), '+0' ),
 
 			array( QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), '+0.6' ),
-			array( QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2' ),
+			array( QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2.0' ),
 			array( QuantityValue::newFromNumber( '+11.5', '1', '+15', '+10.5' ), '+3.5' ),
+
+			'Unknown uncertainty' => array( QuantityValue::newFromNumber( '+0' ), null ),
 		);
 	}
 
@@ -204,16 +261,14 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider getOrderOfUncertaintyProvider
 	 */
 	public function testGetOrderOfUncertainty( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getOrderOfUncertainty();
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $quantity->getOrderOfUncertainty() );
 	}
 
 	public function getOrderOfUncertaintyProvider() {
 		return array(
-			0 => array( QuantityValue::newFromNumber( '+0' ), 0 ),
-			1 => array( QuantityValue::newFromNumber( '-123' ), 0 ),
-			2 => array( QuantityValue::newFromNumber( '-1.23' ), -2 ),
+			0 => array( QuantityValue::newFromNumber( '+0' ), null ),
+			1 => array( QuantityValue::newFromNumber( '-123' ), null ),
+			2 => array( QuantityValue::newFromNumber( '-1.23' ), null ),
 
 			10 => array( QuantityValue::newFromNumber( '-100', '1', '-99', '-101' ), 0 ),
 			11 => array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), -2 ),
@@ -226,6 +281,8 @@ class QuantityValueTest extends DataValueTest {
 			24 => array( QuantityValue::newFromNumber( '-2', '1', '+1.1', '-120' ), 0 ),
 			25 => array( QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900.03' ), 1 ),
 			26 => array( QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900' ), 2 ),
+
+			'Unknown uncertainty' => array( QuantityValue::newFromNumber( '+0' ), null ),
 		);
 	}
 
@@ -233,16 +290,14 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider getSignificantFiguresProvider
 	 */
 	public function testGetSignificantFigures( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getSignificantFigures();
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $quantity->getSignificantFigures() );
 	}
 
 	public function getSignificantFiguresProvider() {
 		return array(
 			0 => array( QuantityValue::newFromNumber( '+0' ), 1 ),
 			1 => array( QuantityValue::newFromNumber( '-123' ), 3 ),
-			2 => array( QuantityValue::newFromNumber( '-1.23' ), 4 ),
+			2 => array( QuantityValue::newFromNumber( '-1.23' ), 1 ),
 
 			10 => array( QuantityValue::newFromNumber( '-100', '1', '-99', '-101' ), 3 ),
 			11 => array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), 4 ),
@@ -266,13 +321,10 @@ class QuantityValueTest extends DataValueTest {
 		$extraArgs = array_slice( $args, 3 );
 
 		$call = array( $quantity, 'transform' );
-		$callArgs = array_merge( array( 'x', $transformation ), $extraArgs );
+		$callArgs = array_merge( array( '?', $transformation ), $extraArgs );
 		$actual = call_user_func_array( $call, $callArgs );
 
-		$this->assertEquals( 'x', $actual->getUnit() );
-		$this->assertEquals( $expected->getAmount()->getValue(), $actual->getAmount()->getValue(), 'value' );
-		$this->assertEquals( $expected->getUpperBound()->getValue(), $actual->getUpperBound()->getValue(), 'upper bound' );
-		$this->assertEquals( $expected->getLowerBound()->getValue(), $actual->getLowerBound()->getValue(), 'lower bound' );
+		$this->assertTrue( $expected->equals( $actual ), "Expected $expected, got $actual" );
 	}
 
 	public function transformProvider() {
@@ -294,14 +346,20 @@ class QuantityValueTest extends DataValueTest {
 			 1 => array( QuantityValue::newFromNumber(  '-0.5', '1', '-0.4', '-0.6' ), $identity, QuantityValue::newFromNumber(    '-0.5',  '?',    '-0.4',  '-0.6' ) ),
 			 2 => array( QuantityValue::newFromNumber(  '+0',   '1', '+1',   '-1' ),   $square,   QuantityValue::newFromNumber(    '+0',    '?',    '+1',    '-1' ) ),
 			 3 => array( QuantityValue::newFromNumber( '+10',   '1', '+11',  '+9' ),   $square,   QuantityValue::newFromNumber( '+1000',    '?', '+1300',  '+700' ) ), // note how rounding applies to bounds
-			 4 => array( QuantityValue::newFromNumber(  '+0.5', '1', '+0.6', '+0.4' ), $scale,    QuantityValue::newFromNumber(    '+0.25', '?',    '+0.3',  '+0.2' ), 0.5 ),
+			 4 => array( QuantityValue::newFromNumber(  '+0.5', '1', '+0.6', '+0.4' ), $scale,    QuantityValue::newFromNumber(    '+0.25', '?',    '+0.30',  '+0.20' ), 0.5 ),
 
 			// note: absolutely exact values require conversion with infinite precision!
-			10 => array( QuantityValue::newFromNumber( '+100', '1', '+100',   '+100' ),    $scale, QuantityValue::newFromNumber( '+12825.0', '?', '+12825.0', '+12825.0' ), 128.25 ),
+			10 => array( QuantityValue::newFromNumber( '+100', '1', '+100',   '+100' ),    $scale, QuantityValue::newFromNumber( '+12825', '?', '+12825', '+12825' ), 128.25 ),
 
 			11 => array( QuantityValue::newFromNumber( '+100', '1', '+110',    '+90' ),    $scale, QuantityValue::newFromNumber( '+330',    '?', '+370',    '+300' ), 3.3333 ),
 			12 => array( QuantityValue::newFromNumber( '+100', '1', '+100.1',  '+99.9' ),  $scale, QuantityValue::newFromNumber( '+333.3',  '?', '+333.7',  '+333.0' ), 3.3333 ),
 			13 => array( QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.99' ), $scale, QuantityValue::newFromNumber( '+333.33', '?', '+333.36', '+333.30' ), 3.3333 ),
+
+			'Unknown uncertainty' => array(
+				QuantityValue::newFromNumber( '+0' ),
+				$identity,
+				QuantityValue::newFromNumber( '+0', '?', null, null )
+			),
 		);
 	}
 

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -93,6 +93,8 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 		) );
 
 		return array(
+			'Unknown uncertainty' => array( QuantityValue::newFromNumber( '+2', '1', null, null ), '2', $withMargin ),
+
 			'+0/nm' => array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0', $noMargin ),
 			'+0/wm' => array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0', $withMargin ),
 

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -65,6 +65,10 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 	 */
 	public function validProvider() {
 		return array(
+			'Unknown uncertainty' => array(
+				QuantityValue::newFromNumber( '+2', '1', null, null ),
+				'2'
+			),
 			'Unit 1' => array(
 				QuantityValue::newFromNumber( '+2', '1', '+3', '+1' ),
 				'2±1'


### PR DESCRIPTION
* ~~Tests missing.~~
* ~~Some method will still explode when the bounds are null.~~
* ~~Formatter and parser must be adopted.~~

Breaking because users of this class don't expect this to be null.

[Bug: T115270](https://phabricator.wikimedia.org/T115270)
[Bug: T133042](https://phabricator.wikimedia.org/T133042)