### PR TITLE
Use self instead of static

### DIFF
--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -345,7 +345,7 @@ class DecimalValue extends DataValueObject {
 	 *
 	 * @param string|int|float $data
 	 *
-	 * @return static
+	 * @return self
 	 * @throws IllegalValueException
 	 */
 	public static function newFromArray( $data ) {

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -478,7 +478,7 @@ class QuantityValue extends DataValueObject {
 	 *
 	 * @param mixed $data
 	 *
-	 * @return static
+	 * @return self
 	 * @throws IllegalValueException
 	 */
 	public static function newFromArray( $data ) {


### PR DESCRIPTION
I started using `static` as a keyword, but it turns out PHPStorm does not understand it.