### PR TITLE
When guessing precision from digits, use +/-0.5 as the margin, not +/-1

### DIFF
--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -327,8 +327,9 @@ class DecimalValue extends DataValueObject {
 	 *
 	 * @return DecimalValue
 	 */
-	public function trim() {
-		$trimmed = preg_replace( '/(\.[\d]+?)0+$/', '\1', $this->value );
+	public function getTrimmed() {
+		$trimmed = preg_replace( '/(\.\d+?)0+$/', '$1', $this->value );
+		$trimmed = preg_replace( '/(?<=\d)\.0*$/', '', $trimmed );
 
 		if ( $trimmed !== $this->value ) {
 			return new DecimalValue( $trimmed );

--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -321,6 +321,23 @@ class DecimalValue extends DataValueObject {
 	}
 
 	/**
+	 * Returns a DecimalValue with the same digits as this one, but with any trailing zeros
+	 * after the decimal point removed. If there are no trailing zeros after the decimal
+	 * point, this method will return $this.
+	 *
+	 * @return DecimalValue
+	 */
+	public function trim() {
+		$trimmed = preg_replace( '/(\.[\d]+?)0+$/', '\1', $this->value );
+
+		if ( $trimmed !== $this->value ) {
+			return new DecimalValue( $trimmed );
+		} else {
+			return $this;
+		}
+	}
+
+	/**
 	 * Returns the value held by this object, as a float.
 	 * Equivalent to floatval( $this->getvalue() ).
 	 *

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -224,9 +224,7 @@ class QuantityFormatter extends ValueFormatterBase {
 	 */
 	private function formatMinimalDecimal( DecimalValue $decimal ) {
 		// TODO: This should be an option of DecimalFormatter.
-		return preg_replace( '/(\.\d+?)0+$/', '$1',
-			preg_replace( '/(?<=\d)\.0*$/', '', $this->decimalFormatter->format( $decimal ) )
-		);
+		return $this->decimalFormatter->format( $decimal->getTrimmed() );
 	}
 
 	/**

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -225,9 +225,12 @@ class QuantityParser extends StringValueParser {
 	 * a level of uncertainty based on the digits given.
 	 *
 	 * The upper and lower bounds are determined automatically from the given
-	 * digits by increasing resp. decreasing the least significant digit.
-	 * E.g. "+0.01" would have upperBound "+0.02" and lowerBound "+0.01",
-	 * while "-100" would have upperBound "-99" and lowerBound "-101".
+	 * digits by adding/subtracting half the order of magnitude of the least
+	 * significant digit. Trailing zeros before the decimal point are considered
+	 * significant.
+	 *
+	 * E.g. "+0.01" would have upperBound "+0.015" and lowerBound "+0.005",
+	 * while "-100" would have upperBound "-99.5" and lowerBound "-100.5".
 	 *
 	 * @param DecimalValue $amount The quantity
 	 * @param string $unit The quantity's unit (use "1" for unit-less quantities)
@@ -238,14 +241,19 @@ class QuantityParser extends StringValueParser {
 	private function newUncertainQuantityFromDigits( DecimalValue $amount, $unit = '1', $exponent = 0 ) {
 		$math = new DecimalMath();
 
-		if ( $amount->getSign() === '+' ) {
-			$upperBound = $math->bump( $amount );
-			$lowerBound = $math->slump( $amount );
-		} else {
-			$upperBound = $math->slump( $amount );
-			$lowerBound = $math->bump( $amount );
-		}
+		// add/subtract one from least significant digit
+		$hi = $math->bump( $amount );
+		$lo = $math->slump( $amount );
 
+		// compute margin = abs( hi - lo ) / 4.
+		$hilo = $math->sum( $hi, $lo->computeComplement() )->computeAbsolute();
+		$margin = $math->product( $hilo, new DecimalValue( '0.25' ) );
+
+		// bounds = amount +/- margin
+		$upperBound = $math->sum( $amount, $margin )->trim();
+		$lowerBound = $math->sum( $amount, $margin->computeComplement() )->trim();
+
+		// apply exponent
 		$amount = $this->decimalParser->applyDecimalExponent( $amount, $exponent );
 		$lowerBound = $this->decimalParser->applyDecimalExponent( $lowerBound, $exponent );
 		$upperBound = $this->decimalParser->applyDecimalExponent( $upperBound, $exponent );

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -250,8 +250,8 @@ class QuantityParser extends StringValueParser {
 		$margin = $math->product( $hilo, new DecimalValue( '0.25' ) );
 
 		// bounds = amount +/- margin
-		$upperBound = $math->sum( $amount, $margin )->trim();
-		$lowerBound = $math->sum( $amount, $margin->computeComplement() )->trim();
+		$upperBound = $math->sum( $amount, $margin )->getTrimmed();
+		$lowerBound = $math->sum( $amount, $margin->computeComplement() )->getTrimmed();
 
 		// apply exponent
 		$amount = $this->decimalParser->applyDecimalExponent( $amount, $exponent );

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -241,19 +241,19 @@ class QuantityParser extends StringValueParser {
 	private function newUncertainQuantityFromDigits( DecimalValue $amount, $unit = '1', $exponent = 0 ) {
 		$math = new DecimalMath();
 
-		// add/subtract one from least significant digit
-		$hi = $math->bump( $amount );
-		$lo = $math->slump( $amount );
+		// Add/subtract one from least significant digit
+		$high = $math->bump( $amount );
+		$low = $math->slump( $amount );
 
-		// compute margin = abs( hi - lo ) / 4.
-		$hilo = $math->sum( $hi, $lo->computeComplement() )->computeAbsolute();
-		$margin = $math->product( $hilo, new DecimalValue( '0.25' ) );
+		// Compute margin = abs( high - low ) / 4.
+		$highLow = $math->sum( $high, $low->computeComplement() )->computeAbsolute();
+		$margin = $math->product( $highLow, new DecimalValue( '0.25' ) );
 
-		// bounds = amount +/- margin
+		// Bounds = amount +/- margin
 		$upperBound = $math->sum( $amount, $margin )->getTrimmed();
 		$lowerBound = $math->sum( $amount, $margin->computeComplement() )->getTrimmed();
 
-		// apply exponent
+		// Apply exponent
 		$amount = $this->decimalParser->applyDecimalExponent( $amount, $exponent );
 		$lowerBound = $this->decimalParser->applyDecimalExponent( $lowerBound, $exponent );
 		$upperBound = $this->decimalParser->applyDecimalExponent( $upperBound, $exponent );

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -321,21 +321,21 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	/**
-	 * @dataProvider trimProvider
+	 * @dataProvider provideGetTrim
 	 */
-	public function testTrim( DecimalValue $value, DecimalValue $expected ) {
-		$actual = $value->trim();
+	public function testGetTrim( DecimalValue $value, DecimalValue $expected ) {
+		$actual = $value->getTrimmed();
 		$this->assertSame( $expected->getValue(), $actual->getValue() );
 	}
 
-	public function trimProvider() {
+	public function provideGetTrim() {
 		return array(
 			array( new DecimalValue(  '+8' ),     new DecimalValue(  '+8' ) ),
 			array( new DecimalValue(  '+80' ),    new DecimalValue(  '+80' ) ),
 			array( new DecimalValue(  '+800' ),   new DecimalValue(  '+800' ) ),
 			array( new DecimalValue(  '+0' ),     new DecimalValue(  '+0' ) ),
-			array( new DecimalValue(  '+0.0' ),   new DecimalValue(  '+0.0' ) ),
-			array( new DecimalValue(  '+0.00' ),  new DecimalValue(  '+0.0' ) ),
+			array( new DecimalValue(  '+0.0' ),   new DecimalValue(  '+0' ) ),
+			array( new DecimalValue(  '+10.00' ), new DecimalValue(  '+10' ) ),
 			array( new DecimalValue(  '-0.1' ),   new DecimalValue(  '-0.1' ) ),
 			array( new DecimalValue(  '-0.10' ),  new DecimalValue(  '-0.1' ) ),
 			array( new DecimalValue(  '-0.010' ), new DecimalValue(  '-0.01' ) ),

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -320,4 +320,27 @@ class DecimalValueTest extends DataValueTest {
 		);
 	}
 
+	/**
+	 * @dataProvider trimProvider
+	 */
+	public function testTrim( DecimalValue $value, DecimalValue $expected ) {
+		$actual = $value->trim();
+		$this->assertSame( $expected->getValue(), $actual->getValue() );
+	}
+
+	public function trimProvider() {
+		return array(
+			array( new DecimalValue(  '+8' ),     new DecimalValue(  '+8' ) ),
+			array( new DecimalValue(  '+80' ),    new DecimalValue(  '+80' ) ),
+			array( new DecimalValue(  '+800' ),   new DecimalValue(  '+800' ) ),
+			array( new DecimalValue(  '+0' ),     new DecimalValue(  '+0' ) ),
+			array( new DecimalValue(  '+0.0' ),   new DecimalValue(  '+0.0' ) ),
+			array( new DecimalValue(  '+0.00' ),  new DecimalValue(  '+0.0' ) ),
+			array( new DecimalValue(  '-0.1' ),   new DecimalValue(  '-0.1' ) ),
+			array( new DecimalValue(  '-0.10' ),  new DecimalValue(  '-0.1' ) ),
+			array( new DecimalValue(  '-0.010' ), new DecimalValue(  '-0.01' ) ),
+			array( new DecimalValue(  '-0.001' ), new DecimalValue(  '-0.001' ) ),
+		);
+	}
+
 }

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -330,16 +330,16 @@ class DecimalValueTest extends DataValueTest {
 
 	public function provideGetTrim() {
 		return array(
-			array( new DecimalValue(  '+8' ),     new DecimalValue(  '+8' ) ),
-			array( new DecimalValue(  '+80' ),    new DecimalValue(  '+80' ) ),
-			array( new DecimalValue(  '+800' ),   new DecimalValue(  '+800' ) ),
-			array( new DecimalValue(  '+0' ),     new DecimalValue(  '+0' ) ),
-			array( new DecimalValue(  '+0.0' ),   new DecimalValue(  '+0' ) ),
-			array( new DecimalValue(  '+10.00' ), new DecimalValue(  '+10' ) ),
-			array( new DecimalValue(  '-0.1' ),   new DecimalValue(  '-0.1' ) ),
-			array( new DecimalValue(  '-0.10' ),  new DecimalValue(  '-0.1' ) ),
-			array( new DecimalValue(  '-0.010' ), new DecimalValue(  '-0.01' ) ),
-			array( new DecimalValue(  '-0.001' ), new DecimalValue(  '-0.001' ) ),
+			array( new DecimalValue( '+8' ),     new DecimalValue( '+8' ) ),
+			array( new DecimalValue( '+80' ),    new DecimalValue( '+80' ) ),
+			array( new DecimalValue( '+800' ),   new DecimalValue( '+800' ) ),
+			array( new DecimalValue( '+0' ),     new DecimalValue( '+0' ) ),
+			array( new DecimalValue( '+0.0' ),   new DecimalValue( '+0' ) ),
+			array( new DecimalValue( '+10.00' ), new DecimalValue( '+10' ) ),
+			array( new DecimalValue( '-0.1' ),   new DecimalValue( '-0.1' ) ),
+			array( new DecimalValue( '-0.10' ),  new DecimalValue( '-0.1' ) ),
+			array( new DecimalValue( '-0.010' ), new DecimalValue( '-0.01' ) ),
+			array( new DecimalValue( '-0.001' ), new DecimalValue( '-0.001' ) ),
 		);
 	}
 

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -101,9 +101,9 @@ class QuantityParserTest extends StringValueParserTest {
 			'0!' => QuantityValue::newFromNumber( 0, '1', 0, 0 ),
 			'10.003!' => QuantityValue::newFromNumber( '+10.003', '1', '+10.003', '+10.003' ),
 			'-200!' => QuantityValue::newFromNumber( -200, '1', -200, -200 ),
-			'0~' => QuantityValue::newFromNumber( 0, '1', 1, -1 ),
-			'10.003~' => QuantityValue::newFromNumber( '+10.003', '1', '+10.004', '+10.002' ),
-			'-200~' => QuantityValue::newFromNumber( -200, '1', -199, -201 ),
+			'0~' => QuantityValue::newFromNumber( 0, '1', 0.5, -0.5 ),
+			'10.003~' => QuantityValue::newFromNumber( '+10.003', '1', '+10.0035', '+10.0025' ),
+			'-200~' => QuantityValue::newFromNumber( -200, '1', -199.5, -200.5 ),
 
 			// uncertainty
 			'5.3 +/- 0.2' => QuantityValue::newFromNumber( '+5.3', '1', '+5.5', '+5.1' ),
@@ -124,7 +124,7 @@ class QuantityParserTest extends StringValueParserTest {
 			// units
 			'5.3+-0.2cm' => QuantityValue::newFromNumber( '+5.3', 'cm', '+5.5', '+5.1' ),
 			'10.003! km' => QuantityValue::newFromNumber( '+10.003', 'km', '+10.003', '+10.003' ),
-			'-200~ %  ' => QuantityValue::newFromNumber( -200, '%', -199, -201 ),
+			'-200~ %  ' => QuantityValue::newFromNumber( -200, '%', -199.5, -200.5 ),
 			'100003 m³' => UnboundedQuantityValue::newFromNumber( 100003, 'm³' ),
 			'3.±-0.2µ' => QuantityValue::newFromNumber( '+3', 'µ', '+3.2', '+2.8' ),
 			'+00.20 Å' => UnboundedQuantityValue::newFromNumber( '+0.20', 'Å' ),


### PR DESCRIPTION
That is, 12 is interpreted as 12+/-0.5 = [11.5, 12.5),
instead of 12+/-1 = [11,13). This is consistent with rounding:
all numbers in the uncertainty interval will round to the original
number.

Bug: T105623