### PR TITLE
Use strict assertSame and fix tests

### DIFF
--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -91,10 +91,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		$math = new DecimalMath();
 
 		$actual = $math->product( $a, $b );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 
 		$actual = $math->product( $b, $a );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 	}
 
 	public function productProvider() {
@@ -111,9 +111,9 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 			array( new DecimalValue(  '+2'  ), new DecimalValue(  '+1'  ), '+2' ),
 			array( new DecimalValue(  '+2'  ), new DecimalValue(  '+2'  ), '+4' ),
 
-			array( new DecimalValue(  '+0.5'  ), new DecimalValue(  '+0'  ), '+0' ),
+			array( new DecimalValue( '+0.5' ), new DecimalValue( '+0' ), '+0.0' ),
 			array( new DecimalValue(  '+0.5'  ), new DecimalValue(  '+1'  ), '+0.5' ),
-			array( new DecimalValue(  '+0.5'  ), new DecimalValue(  '+2'  ), '+1' ),
+			array( new DecimalValue( '+0.5' ), new DecimalValue( '+2' ), '+1.0' ),
 		);
 	}
 
@@ -128,10 +128,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		$actual = $math->product( $a, $b );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 
 		$actual = $math->product( $b, $a );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 	}
 
 	public function productWithBCProvider() {
@@ -148,10 +148,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		$math = new DecimalMath();
 
 		$actual = $math->sum( $a, $b );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 
 		$actual = $math->sum( $b, $a );
-		$this->assertEquals( $value, $actual->getValue() );
+		$this->assertSame( $value, $actual->getValue() );
 	}
 
 	public function sumProvider() {
@@ -177,10 +177,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		$math = new DecimalMath();
 
 		$actual = $math->min( $min, $max );
-		$this->assertEquals( $min->getValue(), $actual->getValue() );
+		$this->assertSame( $min->getValue(), $actual->getValue() );
 
 		$actual = $math->min( $max, $min );
-		$this->assertEquals( $min->getValue(), $actual->getValue() );
+		$this->assertSame( $min->getValue(), $actual->getValue() );
 	}
 
 	/**
@@ -190,10 +190,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		$math = new DecimalMath();
 
 		$actual = $math->max( $min, $max );
-		$this->assertEquals( $max->getValue(), $actual->getValue() );
+		$this->assertSame( $max->getValue(), $actual->getValue() );
 
 		$actual = $math->max( $max, $min );
-		$this->assertEquals( $max->getValue(), $actual->getValue() );
+		$this->assertSame( $max->getValue(), $actual->getValue() );
 	}
 
 	public function minMaxProvider() {
@@ -408,7 +408,7 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 		$math = new DecimalMath();
 
 		$actual = $math->shift( $value, $exponent );
-		$this->assertEquals( $expected, $actual->getValue() );
+		$this->assertSame( $expected, $actual->getValue() );
 	}
 
 	public function shiftProvider() {

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -51,35 +51,35 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetValue( QuantityValue $quantity, array $arguments ) {
-		$this->assertInstanceOf( $this->getClass(), $quantity->getValue() );
+		$this->assertSame( $quantity, $quantity->getValue() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetAmount( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[0], $quantity->getAmount() );
+		$this->assertSame( $arguments[0], $quantity->getAmount() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetUnit( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[1], $quantity->getUnit() );
+		$this->assertSame( $arguments[1], $quantity->getUnit() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetUpperBound( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[2], $quantity->getUpperBound() );
+		$this->assertSame( $arguments[2], $quantity->getUpperBound() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetLowerBound( QuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[3], $quantity->getLowerBound() );
+		$this->assertSame( $arguments[3], $quantity->getLowerBound() );
 	}
 
 	/**
@@ -243,26 +243,23 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetSortKey( QuantityValue $quantity ) {
-		$this->assertEquals( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
+		$this->assertSame( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
 	}
 
 	/**
 	 * @dataProvider getUncertaintyProvider
 	 */
 	public function testGetUncertainty( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getUncertainty();
-
-		// floats are wonkey, accept small differences here
-		$this->assertTrue( abs( $actual - $expected ) < 0.000000001, "expected $expected, got $actual" );
+		$this->assertSame( $expected, $quantity->getUncertainty() );
 	}
 
 	public function getUncertaintyProvider() {
 		return array(
-			array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0 ),
+			array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0.0 ),
 
-			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2 ),
+			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2.0 ),
 			array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), 0.02 ),
-			array( QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2 ),
+			array( QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2.0 ),
 			array( QuantityValue::newFromNumber( '+100.0', '1', '+100.1', '+99.9' ), 0.2 ),
 			array( QuantityValue::newFromNumber( '+12.34', '1', '+12.35', '+12.33' ), 0.02 ),
 
@@ -275,9 +272,7 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider getUncertaintyMarginProvider
 	 */
 	public function testGetUncertaintyMargin( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getUncertaintyMargin();
-
-		$this->assertEquals( $expected, $actual->getValue() );
+		$this->assertSame( $expected, $quantity->getUncertaintyMargin()->getValue() );
 	}
 
 	public function getUncertaintyMarginProvider() {
@@ -288,7 +283,7 @@ class QuantityValueTest extends DataValueTest {
 			array( QuantityValue::newFromNumber( '-1', '1', '-1', '-1' ), '+0' ),
 
 			array( QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), '+0.6' ),
-			array( QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2' ),
+			array( QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2.0' ),
 			array( QuantityValue::newFromNumber( '+11.5', '1', '+15', '+10.5' ), '+3.5' ),
 		);
 	}
@@ -297,9 +292,7 @@ class QuantityValueTest extends DataValueTest {
 	 * @dataProvider getOrderOfUncertaintyProvider
 	 */
 	public function testGetOrderOfUncertainty( QuantityValue $quantity, $expected ) {
-		$actual = $quantity->getOrderOfUncertainty();
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $quantity->getOrderOfUncertainty() );
 	}
 
 	public function getOrderOfUncertaintyProvider() {
@@ -333,7 +326,7 @@ class QuantityValueTest extends DataValueTest {
 		$callArgs = array_merge( array( 'x', $transformation ), $extraArgs );
 		$actual = call_user_func_array( $call, $callArgs );
 
-		$this->assertEquals( 'x', $actual->getUnit() );
+		$this->assertSame( 'x', $actual->getUnit() );
 		$this->assertEquals( $expected->getAmount()->getValue(), $actual->getAmount()->getValue(), 'value' );
 		$this->assertEquals( $expected->getUpperBound()->getValue(), $actual->getUpperBound()->getValue(), 'upper bound' );
 		$this->assertEquals( $expected->getLowerBound()->getValue(), $actual->getLowerBound()->getValue(), 'lower bound' );
@@ -354,18 +347,60 @@ class QuantityValueTest extends DataValueTest {
 		};
 
 		return array(
-			 0 => array( QuantityValue::newFromNumber( '+10',   '1', '+11',  '+9' ),   $identity, QuantityValue::newFromNumber(   '+10',    '?',   '+11',    '+9' ) ),
-			 1 => array( QuantityValue::newFromNumber(  '-0.5', '1', '-0.4', '-0.6' ), $identity, QuantityValue::newFromNumber(    '-0.5',  '?',    '-0.4',  '-0.6' ) ),
-			 2 => array( QuantityValue::newFromNumber(  '+0',   '1', '+1',   '-1' ),   $square,   QuantityValue::newFromNumber(    '+0',    '?',    '+1',    '-1' ) ),
-			 3 => array( QuantityValue::newFromNumber( '+10',   '1', '+11',  '+9' ),   $square,   QuantityValue::newFromNumber( '+1000',    '?', '+1300',  '+700' ) ), // note how rounding applies to bounds
-			 4 => array( QuantityValue::newFromNumber(  '+0.5', '1', '+0.6', '+0.4' ), $scale,    QuantityValue::newFromNumber(    '+0.25', '?',    '+0.3',  '+0.2' ), 0.5 ),
+			0 => array(
+				QuantityValue::newFromNumber( '+10', '1', '+11', '+9' ),
+				$identity,
+				QuantityValue::newFromNumber( '+10', '?', '+11', '+9' )
+			),
+			1 => array(
+				QuantityValue::newFromNumber( '-0.5', '1', '-0.4', '-0.6' ),
+				$identity,
+				QuantityValue::newFromNumber( '-0.5', '?', '-0.4', '-0.6' )
+			),
+			2 => array(
+				QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ),
+				$square,
+				QuantityValue::newFromNumber( '+0', '?', '+1', '-1' )
+			),
+			3 => array(
+				QuantityValue::newFromNumber( '+10', '1', '+11', '+9' ),
+				$square,
+				// note how rounding applies to bounds
+				QuantityValue::newFromNumber( '+1000', '?', '+1300', '+700' )
+			),
+			4 => array(
+				QuantityValue::newFromNumber( '+0.5', '1', '+0.6', '+0.4' ),
+				$scale,
+				QuantityValue::newFromNumber( '+0.25', '?', '+0.30', '+0.20' ),
+				0.5
+			),
 
 			// note: absolutely exact values require conversion with infinite precision!
-			10 => array( QuantityValue::newFromNumber( '+100', '1', '+100',   '+100' ),    $scale, QuantityValue::newFromNumber( '+12825.0', '?', '+12825.0', '+12825.0' ), 128.25 ),
+			10 => array(
+				QuantityValue::newFromNumber( '+100', '1', '+100', '+100' ),
+				$scale,
+				QuantityValue::newFromNumber( '+12825', '?', '+12825', '+12825' ),
+				128.25
+			),
 
-			11 => array( QuantityValue::newFromNumber( '+100', '1', '+110',    '+90' ),    $scale, QuantityValue::newFromNumber( '+330',    '?', '+370',    '+300' ), 3.3333 ),
-			12 => array( QuantityValue::newFromNumber( '+100', '1', '+100.1',  '+99.9' ),  $scale, QuantityValue::newFromNumber( '+333.3',  '?', '+333.7',  '+333.0' ), 3.3333 ),
-			13 => array( QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.99' ), $scale, QuantityValue::newFromNumber( '+333.33', '?', '+333.36', '+333.30' ), 3.3333 ),
+			11 => array(
+				QuantityValue::newFromNumber( '+100', '1', '+110', '+90' ),
+				$scale,
+				QuantityValue::newFromNumber( '+330', '?', '+370', '+300' ),
+				3.3333
+			),
+			12 => array(
+				QuantityValue::newFromNumber( '+100', '1', '+100.1', '+99.9' ),
+				$scale,
+				QuantityValue::newFromNumber( '+333.3', '?', '+333.7', '+333.0' ),
+				3.3333
+			),
+			13 => array(
+				QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.99' ),
+				$scale,
+				QuantityValue::newFromNumber( '+333.33', '?', '+333.36', '+333.30' ),
+				3.3333
+			),
 		);
 	}
 

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -48,21 +48,21 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetValue( UnboundedQuantityValue $quantity, array $arguments ) {
-		$this->assertInstanceOf( $this->getClass(), $quantity->getValue() );
+		$this->assertSame( $quantity, $quantity->getValue() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetAmount( UnboundedQuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[0], $quantity->getAmount() );
+		$this->assertSame( $arguments[0], $quantity->getAmount() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetUnit( UnboundedQuantityValue $quantity, array $arguments ) {
-		$this->assertEquals( $arguments[1], $quantity->getUnit() );
+		$this->assertSame( $arguments[1], $quantity->getUnit() );
 	}
 
 	/**
@@ -185,7 +185,7 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	 * @dataProvider instanceProvider
 	 */
 	public function testGetSortKey( UnboundedQuantityValue $quantity ) {
-		$this->assertEquals( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
+		$this->assertSame( $quantity->getAmount()->getValueFloat(), $quantity->getSortKey() );
 	}
 
 	/**
@@ -199,7 +199,7 @@ class UnboundedQuantityValueTest extends DataValueTest {
 		$callArgs = array_merge( array( 'x', $transformation ), $extraArgs );
 		$actual = call_user_func_array( $call, $callArgs );
 
-		$this->assertEquals( 'x', $actual->getUnit() );
+		$this->assertSame( 'x', $actual->getUnit() );
 		$this->assertEquals( $expected->getAmount()->getValue(), $actual->getAmount()->getValue(), 'value' );
 	}
 
@@ -218,15 +218,46 @@ class UnboundedQuantityValueTest extends DataValueTest {
 		};
 
 		return array(
-			 0 => array( UnboundedQuantityValue::newFromNumber( '+10', '1' ), $identity, UnboundedQuantityValue::newFromNumber( '+10', '?' ) ),
-			 1 => array( UnboundedQuantityValue::newFromNumber( '-0.5', '1' ), $identity, UnboundedQuantityValue::newFromNumber( '-0.5', '?' ) ),
-			 2 => array( UnboundedQuantityValue::newFromNumber( '+0', '1' ), $square,   UnboundedQuantityValue::newFromNumber( '+0', '?' ) ),
-			 3 => array( UnboundedQuantityValue::newFromNumber( '+10', '1' ), $square,   UnboundedQuantityValue::newFromNumber( '+1000', '?' ) ), // note how rounding applies to bounds
-			 4 => array( UnboundedQuantityValue::newFromNumber( '+0.5', '1' ), $scale,    UnboundedQuantityValue::newFromNumber( '+0.25', '?' ), 0.5 ),
+			0 => array(
+				UnboundedQuantityValue::newFromNumber( '+10', '1' ),
+				$identity,
+				UnboundedQuantityValue::newFromNumber( '+10', '?' )
+			),
+			1 => array(
+				UnboundedQuantityValue::newFromNumber( '-0.5', '1' ),
+				$identity,
+				UnboundedQuantityValue::newFromNumber( '-0.5', '?' )
+			),
+			2 => array(
+				UnboundedQuantityValue::newFromNumber( '+0', '1' ),
+				$square,
+				UnboundedQuantityValue::newFromNumber( '+0', '?' )
+			),
+			3 => array(
+				UnboundedQuantityValue::newFromNumber( '+10', '1' ),
+				$square,
+				UnboundedQuantityValue::newFromNumber( '+1000', '?' )
+			),
+			4 => array(
+				UnboundedQuantityValue::newFromNumber( '+0.5', '1' ),
+				$scale,
+				UnboundedQuantityValue::newFromNumber( '+0.25', '?' ),
+				0.5
+			),
 
 			// note: absolutely exact values require conversion with infinite precision!
-			10 => array( UnboundedQuantityValue::newFromNumber( '+100', '1' ), $scale, UnboundedQuantityValue::newFromNumber( '+12825.0', '?' ), 128.25 ),
-			13 => array( UnboundedQuantityValue::newFromNumber( '+100', '1' ), $scale, UnboundedQuantityValue::newFromNumber( '+333.33', '?' ), 3.3333 ),
+			10 => array(
+				UnboundedQuantityValue::newFromNumber( '+100', '1' ),
+				$scale,
+				UnboundedQuantityValue::newFromNumber( '+12825', '?' ),
+				128.25
+			),
+			13 => array(
+				UnboundedQuantityValue::newFromNumber( '+100', '1' ),
+				$scale,
+				UnboundedQuantityValue::newFromNumber( '+333.33', '?' ),
+				3.3333
+			),
 		);
 	}
 

--- a/tests/ValueFormatters/BasicNumberLocalizerTest.php
+++ b/tests/ValueFormatters/BasicNumberLocalizerTest.php
@@ -37,7 +37,7 @@ class BasicNumberLocalizerTest extends \PHPUnit_Framework_TestCase {
 		$localizer = new BasicNumberLocalizer();
 		$localized = $localizer->localizeNumber( $localized );
 
-		$this->assertEquals( $expected, $localized );
+		$this->assertSame( $expected, $localized );
 	}
 
 }

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -74,7 +74,7 @@ class DecimalFormatterTest extends ValueFormatterTestBase {
 		$value = new DecimalValue( '+12345' );
 		$formatter = new DecimalFormatter( null, $localizer );
 
-		$this->assertEquals( 'n:12345', $formatter->format( $value ) );
+		$this->assertSame( 'n:12345', $formatter->format( $value ) );
 	}
 
 }

--- a/tests/ValueParsers/BasicNumberUnlocalizerTest.php
+++ b/tests/ValueParsers/BasicNumberUnlocalizerTest.php
@@ -52,7 +52,7 @@ class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 		$unlocalizer = new BasicNumberUnlocalizer();
 		$unlocalized = $unlocalizer->unlocalizeNumber( $localized );
 
-		$this->assertEquals( $expected, $unlocalized );
+		$this->assertSame( $expected, $unlocalized );
 	}
 
 	public function provideGetNumberRegexMatch() {

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -122,9 +122,10 @@ class DecimalParserTest extends StringValueParserTest {
 		$parser = new DecimalParser( null, $unlocalizer );
 
 		$input = '###20#000#000###';
+		/** @var DecimalValue $value */
 		$value = $parser->parse( $input );
 
-		$this->assertEquals( '20000000', $value->getValue() );
+		$this->assertSame( '+20000000', $value->getValue() );
 	}
 
 	public function splitDecimalExponentProvider() {

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -225,10 +225,11 @@ class QuantityParserTest extends StringValueParserTest {
 
 		$parser = new QuantityParser( $options, $unlocalizer );
 
+		/** @var QuantityValue $quantity */
 		$quantity = $parser->parse( '1 22 333,77+-3a~b' );
 
-		$this->assertEquals( '122333.77', $quantity->getAmount() );
-		$this->assertEquals( 'a~b', $quantity->getUnit() );
+		$this->assertSame( '+122333.77', $quantity->getAmount()->getValue() );
+		$this->assertSame( 'a~b', $quantity->getUnit() );
 	}
 
 	/**
@@ -241,7 +242,7 @@ class QuantityParserTest extends StringValueParserTest {
 		$parser = $this->getQuantityParser( $options );
 
 		$quantity = $parser->parse( $value );
-		$this->assertEquals( $expected, $quantity->getUnit() );
+		$this->assertSame( $expected, $quantity->getUnit() );
 	}
 
 	public function unitOptionProvider() {


### PR DESCRIPTION
This replaces lots and lots of insufficient assertions with strict `assertSame` and fixes tests. Details like leading plus signs and trailing zeros are relevant, especially in parsers, but ignored by `assertEquals`.