### PR TITLE
Fix incomplete (Unbounded)QuantityValue::newFromArray deserializers

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_NUMBER_VERSION', '0.8.0' );
+define( 'DATAVALUES_NUMBER_VERSION', '0.8.1' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ DataValues Number has been written by Daniel Kinzler, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.1 (2016-08-02)
+
+* `UnboundedQuantityValue::newFromArray` and `QuantityValue::newFromArray` both accept
+  serializations without and with an uncertainty interval.
+
 ### 0.8.0 (2016-08-01)
 
 * Added `DecimalValue::getTrimmed`.

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -292,26 +292,4 @@ class QuantityValue extends UnboundedQuantityValue {
 		);
 	}
 
-	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with @see getArrayValue
-	 *
-	 * @since 0.1
-	 *
-	 * @param mixed $data
-	 *
-	 * @return self
-	 * @throws IllegalValueException
-	 */
-	public static function newFromArray( $data ) {
-		self::requireArrayFields( $data, array( 'amount', 'unit', 'upperBound', 'lowerBound' ) );
-
-		return new static(
-			DecimalValue::newFromArray( $data['amount'] ),
-			$data['unit'],
-			DecimalValue::newFromArray( $data['upperBound'] ),
-			DecimalValue::newFromArray( $data['lowerBound'] )
-		);
-	}
-
 }

--- a/src/DataValues/UnboundedQuantityValue.php
+++ b/src/DataValues/UnboundedQuantityValue.php
@@ -247,21 +247,33 @@ class UnboundedQuantityValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with @see getArrayValue
+	 * Static helper capable of constructing both unbounded and bounded quantity value objects,
+	 * depending on the serialization provided. Required for @see DataValueDeserializer. This can
+	 * round-trip with both @see self::getArrayValue as well as @see QuantityValue::getArrayValue.
 	 *
-	 * @param mixed $data
+	 * @param array $data
 	 *
-	 * @return self
+	 * @return self|QuantityValue Either an unbounded or bounded quantity value object.
 	 * @throws IllegalValueException
 	 */
-	public static function newFromArray( $data ) {
+	public static function newFromArray( array $data ) {
 		self::requireArrayFields( $data, array( 'amount', 'unit' ) );
 
-		return new static(
-			DecimalValue::newFromArray( $data['amount'] ),
-			$data['unit']
-		);
+		if ( !isset( $data['upperBound'] ) && !isset( $data['lowerBound'] ) ) {
+			return new self(
+				DecimalValue::newFromArray( $data['amount'] ),
+				$data['unit']
+			);
+		} else {
+			self::requireArrayFields( $data, array( 'upperBound', 'lowerBound' ) );
+
+			return new QuantityValue(
+				DecimalValue::newFromArray( $data['amount'] ),
+				$data['unit'],
+				DecimalValue::newFromArray( $data['upperBound'] ),
+				DecimalValue::newFromArray( $data['lowerBound'] )
+			);
+		}
 	}
 
 	/**

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -4,6 +4,7 @@ namespace DataValues\Tests;
 
 use DataValues\DecimalValue;
 use DataValues\QuantityValue;
+use DataValues\UnboundedQuantityValue;
 
 /**
  * @covers DataValues\QuantityValue
@@ -129,7 +130,7 @@ class QuantityValueTest extends DataValueTest {
 	/**
 	 * @dataProvider validArraySerializationProvider
 	 */
-	public function testNewFromArray( $data, QuantityValue $expected ) {
+	public function testNewFromArray( $data, UnboundedQuantityValue $expected ) {
 		$value = QuantityValue::newFromArray( $data );
 		$this->assertTrue( $expected->equals( $value ), $value . ' should equal ' . $expected );
 	}
@@ -144,6 +145,22 @@ class QuantityValueTest extends DataValueTest {
 					'lowerBound' => '+1.5',
 				),
 				QuantityValue::newFromNumber( '+2', '1', '+2.5', '+1.5' )
+			),
+			'unbounded' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+				),
+				UnboundedQuantityValue::newFromNumber( '+2', '1' )
+			),
+			'unbounded with existing array keys' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'upperBound' => null,
+					'lowerBound' => null,
+				),
+				UnboundedQuantityValue::newFromNumber( '+2', '1' )
 			),
 		);
 	}
@@ -184,12 +201,6 @@ class QuantityValueTest extends DataValueTest {
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
-				)
-			),
-			'unbounded' => array(
-				array(
-					'amount' => '+2',
-					'unit' => '1',
 				)
 			),
 			'bad-amount' => array(

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -3,6 +3,7 @@
 namespace DataValues\Tests;
 
 use DataValues\DecimalValue;
+use DataValues\QuantityValue;
 use DataValues\UnboundedQuantityValue;
 
 /**
@@ -124,6 +125,15 @@ class UnboundedQuantityValueTest extends DataValueTest {
 				),
 				UnboundedQuantityValue::newFromNumber( '+2', '1' )
 			),
+			'unbounded with existing array keys' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'upperBound' => null,
+					'lowerBound' => null,
+				),
+				UnboundedQuantityValue::newFromNumber( '+2', '1' )
+			),
 			'with-extra' => array(
 				array(
 					'amount' => '+2',
@@ -131,7 +141,7 @@ class UnboundedQuantityValueTest extends DataValueTest {
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
 				),
-				UnboundedQuantityValue::newFromNumber( '+2', '1' )
+				QuantityValue::newFromNumber( '+2', '1', '+2.5', '+1.5' )
 			),
 		);
 	}
@@ -156,10 +166,40 @@ class UnboundedQuantityValueTest extends DataValueTest {
 					'amount' => '+2',
 				)
 			),
+			'no-upperBound' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'lowerBound' => '+1.5',
+				)
+			),
+			'no-lowerBound' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'upperBound' => '+2.5',
+				)
+			),
 			'bad-amount' => array(
 				array(
 					'amount' => 'x',
 					'unit' => '1',
+				)
+			),
+			'bad-upperBound' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'upperBound' => 'x',
+					'lowerBound' => '+1.5',
+				)
+			),
+			'bad-lowerBound' => array(
+				array(
+					'amount' => '+2',
+					'unit' => '1',
+					'upperBound' => '+2.5',
+					'lowerBound' => 'x',
 				)
 			),
 		);


### PR DESCRIPTION
I consider this a "fix" for the following reason:
* The parser returns either an unbounded or a bounded quantity value.
* The formatter accepts both.
* Both do have a `getArrayValue` method, which is what defines the serialization. The serializers don't know anything about the two classes.
* We are considering the fact that we split the code into two classes an implementation detail.
* Deserialization is done in `DataValueDeserializer`, which calls `newFromArray`. This should still be possible without requiring an "IF upper and lower bound are present THEN deserialize bounded quantity value ELSE deserialize unbounded quantity value". This knowledge should be inside of this component (because it is an implementation detail). Not in Wikibase.git.