### PR TITLE
Fix HTML escaping in QuantityHtmlFormatter

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_NUMBER_VERSION', '0.8.1' );
+define( 'DATAVALUES_NUMBER_VERSION', '0.8.2' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ DataValues Number has been written by Daniel Kinzler, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.8.2 (2016-08-11)
+
+* Fixed HTML escaping in `QuantityHtmlFormatter`.
+
 ### 0.8.1 (2016-08-02)
 
 * `UnboundedQuantityValue::newFromArray` and `QuantityValue::newFromArray` both accept

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -118,24 +118,11 @@ class QuantityFormatter extends ValueFormatterBase {
 	 */
 	public function format( $value ) {
 		if ( !( $value instanceof UnboundedQuantityValue ) ) {
-			throw new InvalidArgumentException( 'Data value type mismatch. Expected a UnboundedQuantityValue.' );
+			throw new InvalidArgumentException( 'Data value type mismatch. Expected an UnboundedQuantityValue.' );
 		}
 
-		return $this->formatQuantityValue( $value );
-	}
-
-	/**
-	 * @since 0.6
-	 *
-	 * @param UnboundedQuantityValue|QuantityValue $quantity
-	 *
-	 * @return string Text
-	 */
-	protected function formatQuantityValue( UnboundedQuantityValue $quantity ) {
-		$formatted = $quantity instanceof QuantityValue
-			? $this->formatNumber( $quantity )
-			: $this->formatUnboundedQuantityValue( $quantity );
-		$unit = $this->formatUnit( $quantity->getUnit() );
+		$formatted = $this->formatNumber( $value );
+		$unit = $this->formatUnit( $value->getUnit() );
 
 		if ( $unit !== null ) {
 			$formatted = strtr(
@@ -148,6 +135,19 @@ class QuantityFormatter extends ValueFormatterBase {
 		}
 
 		return $formatted;
+	}
+
+	/**
+	 * @since 0.8.2
+	 *
+	 * @param UnboundedQuantityValue $quantity
+	 *
+	 * @return string Text
+	 */
+	protected function formatNumber( UnboundedQuantityValue $quantity ) {
+		return $quantity instanceof QuantityValue
+			? $this->formatQuantityValue( $quantity )
+			: $this->formatUnboundedQuantityValue( $quantity );
 	}
 
 	/**
@@ -167,13 +167,11 @@ class QuantityFormatter extends ValueFormatterBase {
 	}
 
 	/**
-	 * @since 0.6
-	 *
 	 * @param QuantityValue $quantity
 	 *
 	 * @return string Text
 	 */
-	protected function formatNumber( QuantityValue $quantity ) {
+	private function formatQuantityValue( QuantityValue $quantity ) {
 		$roundingExponent = $this->getRoundingExponent( $quantity );
 
 		$amount = $quantity->getAmount();

--- a/src/ValueFormatters/QuantityHtmlFormatter.php
+++ b/src/ValueFormatters/QuantityHtmlFormatter.php
@@ -2,7 +2,7 @@
 
 namespace ValueFormatters;
 
-use DataValues\QuantityValue;
+use DataValues\UnboundedQuantityValue;
 
 /**
  * HTML formatter for quantity values.
@@ -17,11 +17,11 @@ class QuantityHtmlFormatter extends QuantityFormatter {
 	/**
 	 * @see QuantityFormatter::formatNumber
 	 *
-	 * @param QuantityValue $quantity
+	 * @param UnboundedQuantityValue $quantity
 	 *
 	 * @return string HTML
 	 */
-	protected function formatNumber( QuantityValue $quantity ) {
+	protected function formatNumber( UnboundedQuantityValue $quantity ) {
 		$formatted = parent::formatNumber( $quantity );
 
 		return htmlspecialchars( $formatted );


### PR DESCRIPTION
The bug is of no consequence because all these values are validated with a regular expression that (currently) does not allow any problematic characters. Only strings like "+1.2" are allowed.