### PR TITLE
Strip all whitespace in DecimalParser

### DIFF
--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -154,7 +154,7 @@ class DecimalParser extends StringValueParser {
 	 */
 	private function normalizeDecimal( $number ) {
 		// strip fluff
-		$number = preg_replace( '/[ \r\n\t\'_,`]+/u', '', $number );
+		$number = preg_replace( '/[\s\'_,`]+/u', '', $number );
 
 		// strip leading zeros
 		$number = preg_replace( '/^([-+]?)0+([^0]|0$)/', '$1$2', $number );

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -30,7 +30,11 @@ class DecimalParserTest extends StringValueParserTest {
 	 * @return DecimalParser
 	 */
 	protected function getInstance() {
-		return new DecimalParser();
+		$unlocalizer = $this->getMock( 'ValueParsers\NumberUnlocalizer' );
+		$unlocalizer->method( 'unlocalizeNumber' )
+			->will( $this->returnArgument( 0 ) );
+
+		return new DecimalParser( null, $unlocalizer );
 	}
 
 	/**
@@ -67,6 +71,13 @@ class DecimalParserTest extends StringValueParserTest {
 			'100,000' => 100000,
 			'100 000' => 100000,
 			'100\'000' => 100000,
+
+			// U+000C (form feed)
+			"5\f" => 5,
+			// U+00A0 (non-break space)
+			"5\xC2\xA0200" => 5200,
+			// U+202F (narrow no-break space)
+			"5\xE2\x80\xAF300" => 5300,
 		];
 
 		foreach ( $valid as $value => $expected ) {


### PR DESCRIPTION
Instead of coming up with our own definition of what "whitespace" means, I suggest to use the existing definition build in PCRE's `\s` character class. See http://www.pcre.org/original/doc/html/pcrepattern.html.

Note that this is more code cleanup than anything and not relevant in production, because all NumberUnlocalizer implementations already strip all `\s`.