### PR TITLE
Update PHPCS and PHPUnit dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "~0.5"
+		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
+		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {
 		"files" : [
@@ -44,6 +45,9 @@
 	"scripts": {
 		"phpcs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+		],
+		"test": [
+			"vendor/bin/phpunit"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,6 @@
 	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
 	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
 	</rule>
 
 	<rule ref="Generic.ControlStructures" />
@@ -33,6 +32,12 @@
 			<property name="spacing" value="1" />
 		</properties>
 	</rule>
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true" />
+		</properties>
+	</rule>
 
 	<arg name="extensions" value="php" />
+	<arg name="encoding" value="utf8" />
 </ruleset>


### PR DESCRIPTION
* Update PHPCS requirement to use the same version as Wikibase.git.
* Update PHPCS rule set to be closer to the one in Wikibase.git.
* Add PHPUnit as a dependency, as we are doing this everywhere now. This is "incomplete" in so far that CI is not using this yet. But this already helps a lot when running tests locally.