### PR TITLE
Use imports instead of absolute class names

### DIFF
--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -4,6 +4,7 @@ namespace DataValues\Tests;
 
 use DataValues\DecimalMath;
 use DataValues\DecimalValue;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers DataValues\DecimalMath
@@ -14,7 +15,7 @@ use DataValues\DecimalValue;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class DecimalMathTest extends \PHPUnit_Framework_TestCase {
+class DecimalMathTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider bumpProvider

--- a/tests/ValueFormatters/BasicNumberLocalizerTest.php
+++ b/tests/ValueFormatters/BasicNumberLocalizerTest.php
@@ -2,6 +2,7 @@
 
 namespace ValueParsers\Test;
 
+use PHPUnit_Framework_TestCase;
 use ValueFormatters\BasicNumberLocalizer;
 
 /**
@@ -13,7 +14,7 @@ use ValueFormatters\BasicNumberLocalizer;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class BasicNumberLocalizerTest extends \PHPUnit_Framework_TestCase {
+class BasicNumberLocalizerTest extends PHPUnit_Framework_TestCase {
 
 	public function provideLocalizeNumber() {
 		return array(

--- a/tests/ValueParsers/BasicNumberUnlocalizerTest.php
+++ b/tests/ValueParsers/BasicNumberUnlocalizerTest.php
@@ -2,6 +2,7 @@
 
 namespace ValueParsers\Test;
 
+use PHPUnit_Framework_TestCase;
 use ValueParsers\BasicNumberUnlocalizer;
 
 /**
@@ -13,7 +14,7 @@ use ValueParsers\BasicNumberUnlocalizer;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
+class BasicNumberUnlocalizerTest extends PHPUnit_Framework_TestCase {
 
 	public function provideUnlocalizeNumber() {
 		return array(


### PR DESCRIPTION
The tests in #96 fail with Travis complaining it can't find the PHPUnit_Framework_TestCase class. Lets see if this change helps.