### PR TITLE
Require BCMath PHP extension via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"require-dev": {
+		"ext-bcmath": "*",
 		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
 		"phpunit/phpunit": "~4.8"
 	},

--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -123,10 +123,6 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	public function testProductWithBC( DecimalValue $a, DecimalValue $b, $value ) {
 		$math = new DecimalMath();
 
-		if ( !$math->getUseBC() ) {
-			$this->markTestSkipped( 'bcmath library not available' );
-		}
-
 		$actual = $math->product( $a, $b );
 		$this->assertSame( $value, $actual->getValue() );
 


### PR DESCRIPTION
The production code also works without the BCMath extension, but the tests don't. I believe it's impossible to test both the same time (how would you disable a PHP module in the middle of a PHPUnit test?). I believe the best solution is to straight away require the extension, at least in all test scenarios.