### PR TITLE
Use Wikibase's CodeSniffer instead of MediaWiki's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
 	},
 	"require-dev": {
 		"ext-bcmath": "*",
-		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
-		"phpunit/phpunit": "~4.8"
+		"phpunit/phpunit": "~4.8",
+		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"autoload": {
 		"files" : [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,43 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="DataValuesNumber">
-	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
-	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
-	</rule>
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
-	<rule ref="Generic.ControlStructures" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="126" />
 		</properties>
 	</rule>
-	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-
-	<rule ref="PSR1" />
-	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-		<exclude-pattern>tests*Test*\.php</exclude-pattern>
-	</rule>
-
-	<rule ref="PSR2.Files" />
-
-	<rule ref="Squiz.Classes.DuplicateProperty" />
-	<rule ref="Squiz.Classes.SelfMemberReference" />
-	<rule ref="Squiz.ControlStructures.ControlSignature" />
-	<rule ref="Squiz.Functions.FunctionDuplicateArgument" />
-	<rule ref="Squiz.Functions.GlobalFunction" />
-	<rule ref="Squiz.Scope" />
-	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
-		<properties>
-			<property name="spacing" value="1" />
-		</properties>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true" />
-		</properties>
-	</rule>
-
-	<arg name="extensions" value="php" />
-	<arg name="encoding" value="utf8" />
 </ruleset>


### PR DESCRIPTION
Note that nothing is left in the local phpcs.xml rule set, except very few actual exceptions from the base rule set:
* OperatorSpacing is fixed in #99.
* Array syntax will be changed in a separate patch.