### PR TITLE
Change all code to use short array syntax

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -18,16 +18,16 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 define( 'DATAVALUES_NUMBER_VERSION', '0.8.3 dev' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
-	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(
+	$GLOBALS['wgExtensionCredits']['datavalues'][] = [
 		'path' => __DIR__,
 		'name' => 'DataValues Number',
 		'version' => DATAVALUES_NUMBER_VERSION,
-		'author' => array(
+		'author' => [
 			'Daniel Kinzler',
 			'Thiemo Mättig',
-		),
+		],
 		'url' => 'https://github.com/DataValues/Number',
 		'description' => 'Numerical value objects, parsers and formatters',
 		'license-name' => 'GPL-2.0+'
-	);
+	];
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,6 @@
 <ruleset name="DataValuesNumber">
 	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
 	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
 	</rule>
 

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -98,12 +98,12 @@ class QuantityValue extends UnboundedQuantityValue {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( array(
+		return serialize( [
 			$this->amount,
 			$this->unit,
 			$this->upperBound,
 			$this->lowerBound,
-		) );
+		] );
 	}
 
 	/**
@@ -284,12 +284,12 @@ class QuantityValue extends UnboundedQuantityValue {
 	 * @return array
 	 */
 	public function getArrayValue() {
-		return array(
+		return [
 			'amount' => $this->amount->getArrayValue(),
 			'unit' => $this->unit,
 			'upperBound' => $this->upperBound->getArrayValue(),
 			'lowerBound' => $this->lowerBound->getArrayValue(),
-		);
+		];
 	}
 
 }

--- a/src/DataValues/UnboundedQuantityValue.php
+++ b/src/DataValues/UnboundedQuantityValue.php
@@ -116,10 +116,10 @@ class UnboundedQuantityValue extends DataValueObject {
 	 * @return string
 	 */
 	public function serialize() {
-		return serialize( array(
+		return serialize( [
 			$this->amount,
 			$this->unit
-		) );
+		] );
 	}
 
 	/**
@@ -240,10 +240,10 @@ class UnboundedQuantityValue extends DataValueObject {
 	 * @return array
 	 */
 	public function getArrayValue() {
-		return array(
+		return [
 			'amount' => $this->amount->getArrayValue(),
 			'unit' => $this->unit,
-		);
+		];
 	}
 
 	/**
@@ -257,7 +257,7 @@ class UnboundedQuantityValue extends DataValueObject {
 	 * @throws IllegalValueException
 	 */
 	public static function newFromArray( array $data ) {
-		self::requireArrayFields( $data, array( 'amount', 'unit' ) );
+		self::requireArrayFields( $data, [ 'amount', 'unit' ] );
 
 		if ( !isset( $data['upperBound'] ) && !isset( $data['lowerBound'] ) ) {
 			return new self(
@@ -265,7 +265,7 @@ class UnboundedQuantityValue extends DataValueObject {
 				$data['unit']
 			);
 		} else {
-			self::requireArrayFields( $data, array( 'upperBound', 'lowerBound' ) );
+			self::requireArrayFields( $data, [ 'upperBound', 'lowerBound' ] );
 
 			return new QuantityValue(
 				DecimalValue::newFromArray( $data['amount'] ),

--- a/src/ValueFormatters/QuantityFormatter.php
+++ b/src/ValueFormatters/QuantityFormatter.php
@@ -127,10 +127,10 @@ class QuantityFormatter extends ValueFormatterBase {
 		if ( $unit !== null ) {
 			$formatted = strtr(
 				$this->quantityWithUnitFormat,
-				array(
+				[
 					'$1' => $formatted,
 					'$2' => $unit
-				)
+				]
 			);
 		}
 

--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -56,9 +56,9 @@ class DecimalParser extends StringValueParser {
 	 *
 	 * @since 0.5
 	 *
-	 * @example splitDecimalExponent( '1.2' )  is  array( '1.2', 0 )
-	 * @example splitDecimalExponent( '1.2e3' )  is  array( '1.2', 3 )
-	 * @example splitDecimalExponent( '1.2e-2' )  is  array( '1.2', -2 )
+	 * @example splitDecimalExponent( '1.2' ) is [ '1.2', 0 ]
+	 * @example splitDecimalExponent( '1.2e3' ) is [ '1.2', 3 ]
+	 * @example splitDecimalExponent( '1.2e-2' ) is [ '1.2', -2 ]
 	 *
 	 * @param string $valueString A decimal string, possibly using scientific notation.
 	 *
@@ -69,10 +69,10 @@ class DecimalParser extends StringValueParser {
 	public function splitDecimalExponent( $valueString ) {
 		if ( preg_match( '/^(.*)(?:[eE]|x10\^)([-+]?[\d,]+)$/', $valueString, $matches ) ) {
 			$exponent = (int)str_replace( ',', '', $matches[2] );
-			return array( $matches[1], $exponent );
+			return [ $matches[1], $exponent ];
 		}
 
-		return array( $valueString, 0 );
+		return [ $valueString, 0 ];
 	}
 
 	/**

--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -26,24 +26,24 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function bumpProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), '+1' ),
-			array( new DecimalValue( '-0' ), '+1' ),
-			array( new DecimalValue( '+0.0' ), '+0.1' ),
-			array( new DecimalValue( '-0.0' ), '+0.1' ),
-			array( new DecimalValue( '+1' ), '+2' ),
-			array( new DecimalValue( '-1' ), '-2' ),
-			array( new DecimalValue( '+10' ), '+11' ),
-			array( new DecimalValue( '-10' ), '-11' ),
-			array( new DecimalValue( '+9' ), '+10' ),
-			array( new DecimalValue( '-9' ), '-10' ),
-			array( new DecimalValue( '+0.01' ), '+0.02' ),
-			array( new DecimalValue( '-0.01' ), '-0.02' ),
-			array( new DecimalValue( '+0.09' ), '+0.10' ),
-			array( new DecimalValue( '-0.09' ), '-0.10' ),
-			array( new DecimalValue( '+0.9' ), '+1.0' ),
-			array( new DecimalValue( '-0.9' ), '-1.0' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '+1' ],
+			[ new DecimalValue( '-0' ), '+1' ],
+			[ new DecimalValue( '+0.0' ), '+0.1' ],
+			[ new DecimalValue( '-0.0' ), '+0.1' ],
+			[ new DecimalValue( '+1' ), '+2' ],
+			[ new DecimalValue( '-1' ), '-2' ],
+			[ new DecimalValue( '+10' ), '+11' ],
+			[ new DecimalValue( '-10' ), '-11' ],
+			[ new DecimalValue( '+9' ), '+10' ],
+			[ new DecimalValue( '-9' ), '-10' ],
+			[ new DecimalValue( '+0.01' ), '+0.02' ],
+			[ new DecimalValue( '-0.01' ), '-0.02' ],
+			[ new DecimalValue( '+0.09' ), '+0.10' ],
+			[ new DecimalValue( '-0.09' ), '-0.10' ],
+			[ new DecimalValue( '+0.9' ), '+1.0' ],
+			[ new DecimalValue( '-0.9' ), '-1.0' ],
+		];
 	}
 
 	/**
@@ -56,32 +56,32 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function slumpProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), '-1' ),
-			array( new DecimalValue( '-0' ), '-1' ),
-			array( new DecimalValue( '+0.0' ), '-0.1' ),
-			array( new DecimalValue( '-0.0' ), '-0.1' ),
-			array( new DecimalValue( '+0.00' ), '-0.01' ),
-			array( new DecimalValue( '-0.00' ), '-0.01' ),
-			array( new DecimalValue( '+1' ), '+0' ),
-			array( new DecimalValue( '-1' ), '+0' ),
-			array( new DecimalValue( '+1.0' ), '+0.9' ),
-			array( new DecimalValue( '-1.0' ), '-0.9' ),
-			array( new DecimalValue( '+0.1' ), '+0.0' ),
-			array( new DecimalValue( '-0.1' ), '+0.0' ), // zero is always normalized to be positive
-			array( new DecimalValue( '+0.01' ), '+0.00' ),
-			array( new DecimalValue( '-0.01' ), '+0.00' ), // zero is always normalized to be positive
-			array( new DecimalValue( '+12' ), '+11' ),
-			array( new DecimalValue( '-12' ), '-11' ),
-			array( new DecimalValue( '+10' ), '+9' ),
-			array( new DecimalValue( '-10' ), '-9' ),
-			array( new DecimalValue( '+100' ), '+99' ),
-			array( new DecimalValue( '-100' ), '-99' ),
-			array( new DecimalValue( '+0.02' ), '+0.01' ),
-			array( new DecimalValue( '-0.02' ), '-0.01' ),
-			array( new DecimalValue( '+0.10' ), '+0.09' ),
-			array( new DecimalValue( '-0.10' ), '-0.09' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '-1' ],
+			[ new DecimalValue( '-0' ), '-1' ],
+			[ new DecimalValue( '+0.0' ), '-0.1' ],
+			[ new DecimalValue( '-0.0' ), '-0.1' ],
+			[ new DecimalValue( '+0.00' ), '-0.01' ],
+			[ new DecimalValue( '-0.00' ), '-0.01' ],
+			[ new DecimalValue( '+1' ), '+0' ],
+			[ new DecimalValue( '-1' ), '+0' ],
+			[ new DecimalValue( '+1.0' ), '+0.9' ],
+			[ new DecimalValue( '-1.0' ), '-0.9' ],
+			[ new DecimalValue( '+0.1' ), '+0.0' ],
+			[ new DecimalValue( '-0.1' ), '+0.0' ], // zero is always normalized to be positive
+			[ new DecimalValue( '+0.01' ), '+0.00' ],
+			[ new DecimalValue( '-0.01' ), '+0.00' ], // zero is always normalized to be positive
+			[ new DecimalValue( '+12' ), '+11' ],
+			[ new DecimalValue( '-12' ), '-11' ],
+			[ new DecimalValue( '+10' ), '+9' ],
+			[ new DecimalValue( '-10' ), '-9' ],
+			[ new DecimalValue( '+100' ), '+99' ],
+			[ new DecimalValue( '-100' ), '-99' ],
+			[ new DecimalValue( '+0.02' ), '+0.01' ],
+			[ new DecimalValue( '-0.02' ), '-0.01' ],
+			[ new DecimalValue( '+0.10' ), '+0.09' ],
+			[ new DecimalValue( '-0.10' ), '-0.09' ],
+		];
 	}
 
 	/**
@@ -98,23 +98,23 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function productProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+0' ), new DecimalValue( '+1' ), '+0' ),
-			array( new DecimalValue( '+0' ), new DecimalValue( '+2' ), '+0' ),
+		return [
+			[ new DecimalValue( '+0' ), new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+0' ), new DecimalValue( '+1' ), '+0' ],
+			[ new DecimalValue( '+0' ), new DecimalValue( '+2' ), '+0' ],
 
-			array( new DecimalValue( '+1' ), new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+1' ), new DecimalValue( '+1' ), '+1' ),
-			array( new DecimalValue( '+1' ), new DecimalValue( '+2' ), '+2' ),
+			[ new DecimalValue( '+1' ), new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+1' ), new DecimalValue( '+1' ), '+1' ],
+			[ new DecimalValue( '+1' ), new DecimalValue( '+2' ), '+2' ],
 
-			array( new DecimalValue( '+2' ), new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+2' ), new DecimalValue( '+1' ), '+2' ),
-			array( new DecimalValue( '+2' ), new DecimalValue( '+2' ), '+4' ),
+			[ new DecimalValue( '+2' ), new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+2' ), new DecimalValue( '+1' ), '+2' ],
+			[ new DecimalValue( '+2' ), new DecimalValue( '+2' ), '+4' ],
 
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+0' ), '+0.0' ),
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+1' ), '+0.5' ),
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+2' ), '+1.0' ),
-		);
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+0' ), '+0.0' ],
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+1' ), '+0.5' ],
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+2' ), '+1.0' ],
+		];
 	}
 
 	/**
@@ -131,10 +131,10 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function productWithBCProvider() {
-		return array(
-			array( new DecimalValue( '+0.1' ), new DecimalValue( '+0.1' ), '+0.01' ),
-			array( new DecimalValue( '-5000000' ), new DecimalValue( '-0.1' ), '+500000.0' ),
-		);
+		return [
+			[ new DecimalValue( '+0.1' ), new DecimalValue( '+0.1' ), '+0.01' ],
+			[ new DecimalValue( '-5000000' ), new DecimalValue( '-0.1' ), '+500000.0' ],
+		];
 	}
 
 	/**
@@ -151,19 +151,19 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function sumProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+0' ), new DecimalValue( '+1' ), '+1' ),
-			array( new DecimalValue( '+0' ), new DecimalValue( '+2' ), '+2' ),
+		return [
+			[ new DecimalValue( '+0' ), new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+0' ), new DecimalValue( '+1' ), '+1' ],
+			[ new DecimalValue( '+0' ), new DecimalValue( '+2' ), '+2' ],
 
-			array( new DecimalValue( '+2' ), new DecimalValue( '+0' ), '+2' ),
-			array( new DecimalValue( '+2' ), new DecimalValue( '+1' ), '+3' ),
-			array( new DecimalValue( '+2' ), new DecimalValue( '+2' ), '+4' ),
+			[ new DecimalValue( '+2' ), new DecimalValue( '+0' ), '+2' ],
+			[ new DecimalValue( '+2' ), new DecimalValue( '+1' ), '+3' ],
+			[ new DecimalValue( '+2' ), new DecimalValue( '+2' ), '+4' ],
 
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+0' ), '+0.5' ),
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+0.5' ), '+1.0' ),
-			array( new DecimalValue( '+0.5' ), new DecimalValue( '+2' ), '+2.5' ),
-		);
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+0' ), '+0.5' ],
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+0.5' ), '+1.0' ],
+			[ new DecimalValue( '+0.5' ), new DecimalValue( '+2' ), '+2.5' ],
+		];
 	}
 
 	/**
@@ -193,14 +193,14 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function minMaxProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), new DecimalValue( '+0' ) ),
-			array( new DecimalValue( '+1' ), new DecimalValue( '+1' ) ),
-			array( new DecimalValue( '-0.2' ), new DecimalValue( '-0.2' ) ),
+		return [
+			[ new DecimalValue( '+0' ), new DecimalValue( '+0' ) ],
+			[ new DecimalValue( '+1' ), new DecimalValue( '+1' ) ],
+			[ new DecimalValue( '-0.2' ), new DecimalValue( '-0.2' ) ],
 
-			array( new DecimalValue( '-2' ), new DecimalValue( '+1' ) ),
-			array( new DecimalValue( '+0.33333' ), new DecimalValue( '+1' ) ),
-		);
+			[ new DecimalValue( '-2' ), new DecimalValue( '+1' ) ],
+			[ new DecimalValue( '+0.33333' ), new DecimalValue( '+1' ) ],
+		];
 	}
 
 	/**
@@ -214,83 +214,83 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function roundToDigitProvider() {
-		$argLists = array();
+		$argLists = [];
 
 		//NOTE: Rounding is applied using the "round half away from zero" logic.
 
-		$argLists[] = array( new DecimalValue( '-2' ), 0, '+0' ); // no digits left
+		$argLists[] = [ new DecimalValue( '-2' ), 0, '+0' ]; // no digits left
 
-		$argLists[] = array( new DecimalValue( '+0' ), 1, '+0' );
-		$argLists[] = array( new DecimalValue( '+0' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 1, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 3, '+0.0' );
+		$argLists[] = [ new DecimalValue( '+0' ), 1, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 1, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 3, '+0.0' ];
 
-		$argLists[] = array( new DecimalValue( '+1.45' ), 1, '+1' );
-		$argLists[] = array( new DecimalValue( '+1.45' ), 3, '+1.5' );
-		$argLists[] = array( new DecimalValue( '+1.45' ), 4, '+1.45' );
+		$argLists[] = [ new DecimalValue( '+1.45' ), 1, '+1' ];
+		$argLists[] = [ new DecimalValue( '+1.45' ), 3, '+1.5' ];
+		$argLists[] = [ new DecimalValue( '+1.45' ), 4, '+1.45' ];
 
-		$argLists[] = array( new DecimalValue( '-1.45' ), 1, '-1' );
-		$argLists[] = array( new DecimalValue( '-1.45' ), 3, '-1.5' );
-		$argLists[] = array( new DecimalValue( '-1.45' ), 4, '-1.45' );
+		$argLists[] = [ new DecimalValue( '-1.45' ), 1, '-1' ];
+		$argLists[] = [ new DecimalValue( '-1.45' ), 3, '-1.5' ];
+		$argLists[] = [ new DecimalValue( '-1.45' ), 4, '-1.45' ];
 
-		$argLists[] = array( new DecimalValue( '+9.99' ), 1, '+10' );
-		$argLists[] = array( new DecimalValue( '+9.99' ), 3, '+10.0' );
-		$argLists[] = array( new DecimalValue( '+9.99' ), 4, '+9.99' );
+		$argLists[] = [ new DecimalValue( '+9.99' ), 1, '+10' ];
+		$argLists[] = [ new DecimalValue( '+9.99' ), 3, '+10.0' ];
+		$argLists[] = [ new DecimalValue( '+9.99' ), 4, '+9.99' ];
 
-		$argLists[] = array( new DecimalValue( '+135.7' ), 1, '+100' );
-		$argLists[] = array( new DecimalValue( '+135.7' ), 3, '+136' );
-		$argLists[] = array( new DecimalValue( '+135.7' ), 5, '+135.7' );
+		$argLists[] = [ new DecimalValue( '+135.7' ), 1, '+100' ];
+		$argLists[] = [ new DecimalValue( '+135.7' ), 3, '+136' ];
+		$argLists[] = [ new DecimalValue( '+135.7' ), 5, '+135.7' ];
 
-		$argLists[] = array( new DecimalValue( '-2' ), 1, '-2' );
-		$argLists[] = array( new DecimalValue( '-2' ), 2, '-2' );
+		$argLists[] = [ new DecimalValue( '-2' ), 1, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2' ), 2, '-2' ];
 
-		$argLists[] = array( new DecimalValue( '+23' ), 1, '+20' );
-		$argLists[] = array( new DecimalValue( '+23' ), 2, '+23' );
-		$argLists[] = array( new DecimalValue( '+23' ), 3, '+23' );
-		$argLists[] = array( new DecimalValue( '+23' ), 4, '+23' );
+		$argLists[] = [ new DecimalValue( '+23' ), 1, '+20' ];
+		$argLists[] = [ new DecimalValue( '+23' ), 2, '+23' ];
+		$argLists[] = [ new DecimalValue( '+23' ), 3, '+23' ];
+		$argLists[] = [ new DecimalValue( '+23' ), 4, '+23' ];
 
-		$argLists[] = array( new DecimalValue( '-234' ), 1, '-200' );
-		$argLists[] = array( new DecimalValue( '-234' ), 2, '-230' );
-		$argLists[] = array( new DecimalValue( '-234' ), 3, '-234' );
+		$argLists[] = [ new DecimalValue( '-234' ), 1, '-200' ];
+		$argLists[] = [ new DecimalValue( '-234' ), 2, '-230' ];
+		$argLists[] = [ new DecimalValue( '-234' ), 3, '-234' ];
 
-		$argLists[] = array( new DecimalValue( '-2.0' ), 1, '-2' );
-		$argLists[] = array( new DecimalValue( '-2.0' ), 2, '-2' );   // not padded (can't end with decimal point)
-		$argLists[] = array( new DecimalValue( '-2.0' ), 3, '-2.0' );
-		$argLists[] = array( new DecimalValue( '-2.0' ), 4, '-2.0' ); // no extra digits
+		$argLists[] = [ new DecimalValue( '-2.0' ), 1, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2.0' ), 2, '-2' ];   // not padded (can't end with decimal point)
+		$argLists[] = [ new DecimalValue( '-2.0' ), 3, '-2.0' ];
+		$argLists[] = [ new DecimalValue( '-2.0' ), 4, '-2.0' ]; // no extra digits
 
-		$argLists[] = array( new DecimalValue( '-2.000' ), 1, '-2' );
-		$argLists[] = array( new DecimalValue( '-2.000' ), 2, '-2' );
-		$argLists[] = array( new DecimalValue( '-2.000' ), 3, '-2.0' );
-		$argLists[] = array( new DecimalValue( '-2.000' ), 4, '-2.00' );
+		$argLists[] = [ new DecimalValue( '-2.000' ), 1, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2.000' ), 2, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2.000' ), 3, '-2.0' ];
+		$argLists[] = [ new DecimalValue( '-2.000' ), 4, '-2.00' ];
 
-		$argLists[] = array( new DecimalValue( '+2.5' ), 1, '+3' ); // rounded up
-		$argLists[] = array( new DecimalValue( '+2.5' ), 2, '+3' );
-		$argLists[] = array( new DecimalValue( '+2.5' ), 3, '+2.5' );
-		$argLists[] = array( new DecimalValue( '+2.5' ), 4, '+2.5' );
+		$argLists[] = [ new DecimalValue( '+2.5' ), 1, '+3' ]; // rounded up
+		$argLists[] = [ new DecimalValue( '+2.5' ), 2, '+3' ];
+		$argLists[] = [ new DecimalValue( '+2.5' ), 3, '+2.5' ];
+		$argLists[] = [ new DecimalValue( '+2.5' ), 4, '+2.5' ];
 
-		$argLists[] = array( new DecimalValue( '+2.05' ), 1, '+2' );
-		$argLists[] = array( new DecimalValue( '+2.05' ), 2, '+2' );
-		$argLists[] = array( new DecimalValue( '+2.05' ), 3, '+2.1' ); // rounded up
-		$argLists[] = array( new DecimalValue( '+2.05' ), 4, '+2.05' );
+		$argLists[] = [ new DecimalValue( '+2.05' ), 1, '+2' ];
+		$argLists[] = [ new DecimalValue( '+2.05' ), 2, '+2' ];
+		$argLists[] = [ new DecimalValue( '+2.05' ), 3, '+2.1' ]; // rounded up
+		$argLists[] = [ new DecimalValue( '+2.05' ), 4, '+2.05' ];
 
-		$argLists[] = array( new DecimalValue( '-23.05' ), 1, '-20' );
-		$argLists[] = array( new DecimalValue( '-23.05' ), 2, '-23' );
-		$argLists[] = array( new DecimalValue( '-23.05' ), 3, '-23' ); // not padded (can't end with decimal point)
-		$argLists[] = array( new DecimalValue( '-23.05' ), 4, '-23.1' ); // rounded down
-		$argLists[] = array( new DecimalValue( '-23.05' ), 5, '-23.05' );
+		$argLists[] = [ new DecimalValue( '-23.05' ), 1, '-20' ];
+		$argLists[] = [ new DecimalValue( '-23.05' ), 2, '-23' ];
+		$argLists[] = [ new DecimalValue( '-23.05' ), 3, '-23' ]; // not padded (can't end with decimal point)
+		$argLists[] = [ new DecimalValue( '-23.05' ), 4, '-23.1' ]; // rounded down
+		$argLists[] = [ new DecimalValue( '-23.05' ), 5, '-23.05' ];
 
-		$argLists[] = array( new DecimalValue( '+9.33' ), 1, '+9' ); // no rounding
-		$argLists[] = array( new DecimalValue( '+9.87' ), 1, '+10' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+9.87' ), 3, '+9.9' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+99' ), 1, '+100' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+99' ), 2, '+99' ); // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+9.33' ), 1, '+9' ]; // no rounding
+		$argLists[] = [ new DecimalValue( '+9.87' ), 1, '+10' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+9.87' ), 3, '+9.9' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+99' ), 1, '+100' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+99' ), 2, '+99' ]; // rounding ripples up
 
-		$argLists[] = array( new DecimalValue( '-9.33' ), 1, '-9' ); // no rounding
-		$argLists[] = array( new DecimalValue( '-9.87' ), 1, '-10' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-9.87' ), 3, '-9.9' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-99' ), 1, '-100' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-99' ), 2, '-99' ); // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-9.33' ), 1, '-9' ]; // no rounding
+		$argLists[] = [ new DecimalValue( '-9.87' ), 1, '-10' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-9.87' ), 3, '-9.9' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-99' ), 1, '-100' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-99' ), 2, '-99' ]; // rounding ripples down
 
 		return $argLists;
 	}
@@ -306,14 +306,14 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function getPositionForExponentProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( 0, new DecimalValue( '+0' ), 1 );
-		$argLists[] = array( 1, new DecimalValue( '+10.25' ), 1 );
-		$argLists[] = array( 1, new DecimalValue( '-100.25' ), 2 );
-		$argLists[] = array( 2, new DecimalValue( '+100.25' ), 1 );
-		$argLists[] = array( -2, new DecimalValue( '+0.234' ), 4 );
-		$argLists[] = array( -2, new DecimalValue( '+11.234' ), 5 );
+		$argLists[] = [ 0, new DecimalValue( '+0' ), 1 ];
+		$argLists[] = [ 1, new DecimalValue( '+10.25' ), 1 ];
+		$argLists[] = [ 1, new DecimalValue( '-100.25' ), 2 ];
+		$argLists[] = [ 2, new DecimalValue( '+100.25' ), 1 ];
+		$argLists[] = [ -2, new DecimalValue( '+0.234' ), 4 ];
+		$argLists[] = [ -2, new DecimalValue( '+11.234' ), 5 ];
 
 		return $argLists;
 	}
@@ -329,70 +329,70 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function roundToExponentProvider() {
-		$argLists = array();
+		$argLists = [];
 
 		//NOTE: Rounding is applied using the "round half away from zero" logic.
 
-		$argLists[] = array( new DecimalValue( '+0' ), 0, '+0' );
-		$argLists[] = array( new DecimalValue( '+0' ), 1, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 0, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), -5, '+0.0' ); // no extra digits
+		$argLists[] = [ new DecimalValue( '+0' ), 0, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), 1, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 0, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), -5, '+0.0' ]; // no extra digits
 
-		$argLists[] = array( new DecimalValue( '+1.45' ), 0, '+1' );
-		$argLists[] = array( new DecimalValue( '+1.45' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+1.45' ), -5, '+1.45' );
+		$argLists[] = [ new DecimalValue( '+1.45' ), 0, '+1' ];
+		$argLists[] = [ new DecimalValue( '+1.45' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+1.45' ), -5, '+1.45' ];
 
-		$argLists[] = array( new DecimalValue( '+99.99' ), 0, '+100' );
-		$argLists[] = array( new DecimalValue( '+99.99' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+99.99' ), -1, '+100.0' );
-		$argLists[] = array( new DecimalValue( '+99.99' ), -5, '+99.99' );
+		$argLists[] = [ new DecimalValue( '+99.99' ), 0, '+100' ];
+		$argLists[] = [ new DecimalValue( '+99.99' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+99.99' ), -1, '+100.0' ];
+		$argLists[] = [ new DecimalValue( '+99.99' ), -5, '+99.99' ];
 
-		$argLists[] = array( new DecimalValue( '-2' ), 0, '-2' );
-		$argLists[] = array( new DecimalValue( '-2' ), -1, '-2' );
-		$argLists[] = array( new DecimalValue( '-2' ), 1, '+0' );
+		$argLists[] = [ new DecimalValue( '-2' ), 0, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2' ), -1, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2' ), 1, '+0' ];
 
-		$argLists[] = array( new DecimalValue( '+23' ), 0, '+23' );
-		$argLists[] = array( new DecimalValue( '+23' ), 1, '+20' );
-		$argLists[] = array( new DecimalValue( '+23' ), 2, '+0' );
+		$argLists[] = [ new DecimalValue( '+23' ), 0, '+23' ];
+		$argLists[] = [ new DecimalValue( '+23' ), 1, '+20' ];
+		$argLists[] = [ new DecimalValue( '+23' ), 2, '+0' ];
 
-		$argLists[] = array( new DecimalValue( '-234' ), 2, '-200' );
-		$argLists[] = array( new DecimalValue( '-234' ), 1, '-230' );
-		$argLists[] = array( new DecimalValue( '-234' ), 0, '-234' );
+		$argLists[] = [ new DecimalValue( '-234' ), 2, '-200' ];
+		$argLists[] = [ new DecimalValue( '-234' ), 1, '-230' ];
+		$argLists[] = [ new DecimalValue( '-234' ), 0, '-234' ];
 
-		$argLists[] = array( new DecimalValue( '-2.0' ), 0, '-2' );
-		$argLists[] = array( new DecimalValue( '-2.0' ), -1, '-2.0' );
-		$argLists[] = array( new DecimalValue( '-2.0' ), -2, '-2.0' ); // no extra digits
+		$argLists[] = [ new DecimalValue( '-2.0' ), 0, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2.0' ), -1, '-2.0' ];
+		$argLists[] = [ new DecimalValue( '-2.0' ), -2, '-2.0' ]; // no extra digits
 
-		$argLists[] = array( new DecimalValue( '-2.000' ), 0, '-2' );
-		$argLists[] = array( new DecimalValue( '-2.000' ), -1, '-2.0' );
-		$argLists[] = array( new DecimalValue( '-2.000' ), -2, '-2.00' );
+		$argLists[] = [ new DecimalValue( '-2.000' ), 0, '-2' ];
+		$argLists[] = [ new DecimalValue( '-2.000' ), -1, '-2.0' ];
+		$argLists[] = [ new DecimalValue( '-2.000' ), -2, '-2.00' ];
 
-		$argLists[] = array( new DecimalValue( '+2.5' ), 0, '+3' ); // rounded up
-		$argLists[] = array( new DecimalValue( '+2.5' ), -1, '+2.5' );
-		$argLists[] = array( new DecimalValue( '+2.5' ), -2, '+2.5' ); // no extra digits
+		$argLists[] = [ new DecimalValue( '+2.5' ), 0, '+3' ]; // rounded up
+		$argLists[] = [ new DecimalValue( '+2.5' ), -1, '+2.5' ];
+		$argLists[] = [ new DecimalValue( '+2.5' ), -2, '+2.5' ]; // no extra digits
 
-		$argLists[] = array( new DecimalValue( '+2.05' ), 0, '+2' );
-		$argLists[] = array( new DecimalValue( '+2.05' ), -1, '+2.1' ); // rounded up
-		$argLists[] = array( new DecimalValue( '+2.05' ), -2, '+2.05' );
+		$argLists[] = [ new DecimalValue( '+2.05' ), 0, '+2' ];
+		$argLists[] = [ new DecimalValue( '+2.05' ), -1, '+2.1' ]; // rounded up
+		$argLists[] = [ new DecimalValue( '+2.05' ), -2, '+2.05' ];
 
-		$argLists[] = array( new DecimalValue( '-23.05' ), 1, '-20' );
-		$argLists[] = array( new DecimalValue( '-23.05' ), 0, '-23' );
+		$argLists[] = [ new DecimalValue( '-23.05' ), 1, '-20' ];
+		$argLists[] = [ new DecimalValue( '-23.05' ), 0, '-23' ];
 
-		$argLists[] = array( new DecimalValue( '-23.05' ), -1, '-23.1' ); // rounded down
-		$argLists[] = array( new DecimalValue( '-23.05' ), -2, '-23.05' );
+		$argLists[] = [ new DecimalValue( '-23.05' ), -1, '-23.1' ]; // rounded down
+		$argLists[] = [ new DecimalValue( '-23.05' ), -2, '-23.05' ];
 
-		$argLists[] = array( new DecimalValue( '+9.33' ), 0, '+9' ); // no rounding
-		$argLists[] = array( new DecimalValue( '+9.87' ), 0, '+10' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+9.87' ), -1, '+9.9' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+99' ), 1, '+100' ); // rounding ripples up
-		$argLists[] = array( new DecimalValue( '+99' ), 0, '+99' ); // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+9.33' ), 0, '+9' ]; // no rounding
+		$argLists[] = [ new DecimalValue( '+9.87' ), 0, '+10' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+9.87' ), -1, '+9.9' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+99' ), 1, '+100' ]; // rounding ripples up
+		$argLists[] = [ new DecimalValue( '+99' ), 0, '+99' ]; // rounding ripples up
 
-		$argLists[] = array( new DecimalValue( '-9.33' ), 0, '-9' ); // no rounding
-		$argLists[] = array( new DecimalValue( '-9.87' ), 0, '-10' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-9.87' ), -1, '-9.9' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-99' ), 1, '-100' ); // rounding ripples down
-		$argLists[] = array( new DecimalValue( '-99' ), 0, '-99' ); // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-9.33' ), 0, '-9' ]; // no rounding
+		$argLists[] = [ new DecimalValue( '-9.87' ), 0, '-10' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-9.87' ), -1, '-9.9' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-99' ), 1, '-100' ]; // rounding ripples down
+		$argLists[] = [ new DecimalValue( '-99' ), 0, '-99' ]; // rounding ripples down
 
 		return $argLists;
 	}
@@ -408,38 +408,38 @@ class DecimalMathTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function shiftProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( '+0' ), 0, '+0' );
-		$argLists[] = array( new DecimalValue( '+0' ), 1, '+0' );
-		$argLists[] = array( new DecimalValue( '+0' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+0' ), -1, '+0.0' );
-		$argLists[] = array( new DecimalValue( '+0' ), -2, '+0.00' );
+		$argLists[] = [ new DecimalValue( '+0' ), 0, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), 1, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), -1, '+0.0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), -2, '+0.00' ];
 
-		$argLists[] = array( new DecimalValue( '+0.0' ), 0, '+0.0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 1, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 2, '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), -1, '+0.00' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), -2, '+0.000' );
+		$argLists[] = [ new DecimalValue( '+0.0' ), 0, '+0.0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 1, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 2, '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), -1, '+0.00' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), -2, '+0.000' ];
 
-		$argLists[] = array( new DecimalValue( '-125' ), 0, '-125' );
-		$argLists[] = array( new DecimalValue( '-125' ), 1, '-1250' );
-		$argLists[] = array( new DecimalValue( '-125' ), 2, '-12500' );
-		$argLists[] = array( new DecimalValue( '-125' ), -1, '-12.5' );
-		$argLists[] = array( new DecimalValue( '-125' ), -2, '-1.25' );
-		$argLists[] = array( new DecimalValue( '-125' ), -3, '-0.125' );
-		$argLists[] = array( new DecimalValue( '-125' ), -4, '-0.0125' );
+		$argLists[] = [ new DecimalValue( '-125' ), 0, '-125' ];
+		$argLists[] = [ new DecimalValue( '-125' ), 1, '-1250' ];
+		$argLists[] = [ new DecimalValue( '-125' ), 2, '-12500' ];
+		$argLists[] = [ new DecimalValue( '-125' ), -1, '-12.5' ];
+		$argLists[] = [ new DecimalValue( '-125' ), -2, '-1.25' ];
+		$argLists[] = [ new DecimalValue( '-125' ), -3, '-0.125' ];
+		$argLists[] = [ new DecimalValue( '-125' ), -4, '-0.0125' ];
 
-		$argLists[] = array( new DecimalValue( '-2.5' ), 0, '-2.5' );
-		$argLists[] = array( new DecimalValue( '-2.5' ), 1, '-25' );
-		$argLists[] = array( new DecimalValue( '-2.5' ), 2, '-250' );
-		$argLists[] = array( new DecimalValue( '-2.5' ), -1, '-0.25' );
-		$argLists[] = array( new DecimalValue( '-2.5' ), -2, '-0.025' );
-		$argLists[] = array( new DecimalValue( '-2.5' ), -3, '-0.0025' );
+		$argLists[] = [ new DecimalValue( '-2.5' ), 0, '-2.5' ];
+		$argLists[] = [ new DecimalValue( '-2.5' ), 1, '-25' ];
+		$argLists[] = [ new DecimalValue( '-2.5' ), 2, '-250' ];
+		$argLists[] = [ new DecimalValue( '-2.5' ), -1, '-0.25' ];
+		$argLists[] = [ new DecimalValue( '-2.5' ), -2, '-0.025' ];
+		$argLists[] = [ new DecimalValue( '-2.5' ), -3, '-0.0025' ];
 
-		$argLists[] = array( new DecimalValue( '+5' ), -4, '+0.0005' );
-		$argLists[] = array( new DecimalValue( '+5.0' ), -4, '+0.00050' );
-		$argLists[] = array( new DecimalValue( '+5.00' ), -4, '+0.000500' );
+		$argLists[] = [ new DecimalValue( '+5' ), -4, '+0.0005' ];
+		$argLists[] = [ new DecimalValue( '+5.0' ), -4, '+0.00050' ];
+		$argLists[] = [ new DecimalValue( '+5.00' ), -4, '+0.000500' ];
 
 		return $argLists;
 	}

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -25,56 +25,56 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( 42 );
-		$argLists[] = array( -42 );
-		$argLists[] = array( '-42' );
-		$argLists[] = array( 4.2 );
-		$argLists[] = array( -4.2 );
-		$argLists[] = array( '+4.2' );
-		$argLists[] = array( " +4.2\n" );
-		$argLists[] = array( 0 );
-		$argLists[] = array( 0.2 );
-		$argLists[] = array( '-0.42' );
-		$argLists[] = array( '-0.0' );
-		$argLists[] = array( '-0' );
-		$argLists[] = array( '+0' );
-		$argLists[] = array( '+0.0' );
-		$argLists[] = array( '+0.000' );
-		$argLists[] = array( '+1.' . str_repeat( '0', 124 ) );
-		$argLists[] = array( '+1.0' . str_repeat( ' ', 124 ) );
-		$argLists[] = array( '4.2' );
-		$argLists[] = array( " 4.2\n" );
+		$argLists[] = [ 42 ];
+		$argLists[] = [ -42 ];
+		$argLists[] = [ '-42' ];
+		$argLists[] = [ 4.2 ];
+		$argLists[] = [ -4.2 ];
+		$argLists[] = [ '+4.2' ];
+		$argLists[] = [ " +4.2\n" ];
+		$argLists[] = [ 0 ];
+		$argLists[] = [ 0.2 ];
+		$argLists[] = [ '-0.42' ];
+		$argLists[] = [ '-0.0' ];
+		$argLists[] = [ '-0' ];
+		$argLists[] = [ '+0' ];
+		$argLists[] = [ '+0.0' ];
+		$argLists[] = [ '+0.000' ];
+		$argLists[] = [ '+1.' . str_repeat( '0', 124 ) ];
+		$argLists[] = [ '+1.0' . str_repeat( ' ', 124 ) ];
+		$argLists[] = [ '4.2' ];
+		$argLists[] = [ " 4.2\n" ];
 
 		return $argLists;
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( 'foo' );
-		$argLists[] = array( '' );
-		$argLists[] = array( '++4.2' );
-		$argLists[] = array( '--4.2' );
-		$argLists[] = array( '-+4.2' );
-		$argLists[] = array( '+-4.2' );
-		$argLists[] = array( '+/-0' );
-		$argLists[] = array( '-.42' );
-		$argLists[] = array( '+.42' );
-		$argLists[] = array( '.42' );
-		$argLists[] = array( '.0' );
-		$argLists[] = array( '-00' );
-		$argLists[] = array( '−1' );
-		$argLists[] = array( '+01.2' );
-		$argLists[] = array( 'x2' );
-		$argLists[] = array( '2x' );
-		$argLists[] = array( '+0100' );
-		$argLists[] = array( false );
-		$argLists[] = array( true );
-		$argLists[] = array( null );
-		$argLists[] = array( '0x20' );
-		$argLists[] = array( '+1.' . str_repeat( '0', 125 ) );
+		$argLists[] = [ 'foo' ];
+		$argLists[] = [ '' ];
+		$argLists[] = [ '++4.2' ];
+		$argLists[] = [ '--4.2' ];
+		$argLists[] = [ '-+4.2' ];
+		$argLists[] = [ '+-4.2' ];
+		$argLists[] = [ '+/-0' ];
+		$argLists[] = [ '-.42' ];
+		$argLists[] = [ '+.42' ];
+		$argLists[] = [ '.42' ];
+		$argLists[] = [ '.0' ];
+		$argLists[] = [ '-00' ];
+		$argLists[] = [ '−1' ];
+		$argLists[] = [ '+01.2' ];
+		$argLists[] = [ 'x2' ];
+		$argLists[] = [ '2x' ];
+		$argLists[] = [ '+0100' ];
+		$argLists[] = [ false ];
+		$argLists[] = [ true ];
+		$argLists[] = [ null ];
+		$argLists[] = [ '0x20' ];
+		$argLists[] = [ '+1.' . str_repeat( '0', 125 ) ];
 
 		return $argLists;
 	}
@@ -106,31 +106,31 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function compareProvider() {
-		return array(
-			'zero/equal' => array( new DecimalValue( 0 ), new DecimalValue( 0 ), 0 ),
-			'zero-signs/equal' => array( new DecimalValue( '+0' ), new DecimalValue( '-0' ), 0 ),
-			'zero-digits/equal' => array( new DecimalValue( '+0' ), new DecimalValue( '+0.000' ), 0 ),
-			'digits/equal' => array( new DecimalValue( '+2.2' ), new DecimalValue( '+2.2000' ), 0 ),
-			'conversion/equal' => array( new DecimalValue( 2.5 ), new DecimalValue( '+2.50' ), 0 ),
-			'negative/equal' => array( new DecimalValue( '-1.33' ), new DecimalValue( '-1.33' ), 0 ),
+		return [
+			'zero/equal' => [ new DecimalValue( 0 ), new DecimalValue( 0 ), 0 ],
+			'zero-signs/equal' => [ new DecimalValue( '+0' ), new DecimalValue( '-0' ), 0 ],
+			'zero-digits/equal' => [ new DecimalValue( '+0' ), new DecimalValue( '+0.000' ), 0 ],
+			'digits/equal' => [ new DecimalValue( '+2.2' ), new DecimalValue( '+2.2000' ), 0 ],
+			'conversion/equal' => [ new DecimalValue( 2.5 ), new DecimalValue( '+2.50' ), 0 ],
+			'negative/equal' => [ new DecimalValue( '-1.33' ), new DecimalValue( '-1.33' ), 0 ],
 
-			'simple/smaller' => array( new DecimalValue( '+1' ), new DecimalValue( '+2' ), -1 ),
-			'simple/greater' => array( new DecimalValue( '+2' ), new DecimalValue( '+1' ), 1 ),
-			'negative/greater' => array( new DecimalValue( '-1' ), new DecimalValue( '-2' ), 1 ),
-			'negative/smaller' => array( new DecimalValue( '-2' ), new DecimalValue( '-1' ), -1 ),
-			'negative-small/greater' => array( new DecimalValue( '-0.5' ), new DecimalValue( '-0.7' ), 1 ),
-			'negative-small/smaller' => array( new DecimalValue( '-0.7' ), new DecimalValue( '-0.5' ), -1 ),
+			'simple/smaller' => [ new DecimalValue( '+1' ), new DecimalValue( '+2' ), -1 ],
+			'simple/greater' => [ new DecimalValue( '+2' ), new DecimalValue( '+1' ), 1 ],
+			'negative/greater' => [ new DecimalValue( '-1' ), new DecimalValue( '-2' ), 1 ],
+			'negative/smaller' => [ new DecimalValue( '-2' ), new DecimalValue( '-1' ), -1 ],
+			'negative-small/greater' => [ new DecimalValue( '-0.5' ), new DecimalValue( '-0.7' ), 1 ],
+			'negative-small/smaller' => [ new DecimalValue( '-0.7' ), new DecimalValue( '-0.5' ), -1 ],
 
-			'digits/greater' => array( new DecimalValue( '+11' ), new DecimalValue( '+8' ), 1 ),
-			'digits-sub/greater' => array( new DecimalValue( '+11' ), new DecimalValue( '+8.0' ), 1 ),
-			'negative-digits/greater' => array( new DecimalValue( '-11' ), new DecimalValue( '-80' ), 1 ),
-			'small/greater' => array( new DecimalValue( '+0.050' ), new DecimalValue( '+0.005' ), 1 ),
+			'digits/greater' => [ new DecimalValue( '+11' ), new DecimalValue( '+8' ), 1 ],
+			'digits-sub/greater' => [ new DecimalValue( '+11' ), new DecimalValue( '+8.0' ), 1 ],
+			'negative-digits/greater' => [ new DecimalValue( '-11' ), new DecimalValue( '-80' ), 1 ],
+			'small/greater' => [ new DecimalValue( '+0.050' ), new DecimalValue( '+0.005' ), 1 ],
 
-			'signs/greater' => array( new DecimalValue( '+1' ), new DecimalValue( '-8' ), 1 ),
-			'signs/less' => array( new DecimalValue( '-8' ), new DecimalValue( '+1' ), -1 ),
+			'signs/greater' => [ new DecimalValue( '+1' ), new DecimalValue( '-8' ), 1 ],
+			'signs/less' => [ new DecimalValue( '-8' ), new DecimalValue( '+1' ), -1 ],
 
-			'with-and-without-point' => array( new DecimalValue( '+100' ), new DecimalValue( '+100.01' ), -1 ),
-		);
+			'with-and-without-point' => [ new DecimalValue( '+100' ), new DecimalValue( '+100.01' ), -1 ],
+		];
 	}
 
 	/**
@@ -142,15 +142,15 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function getSignProvider() {
-		return array(
-			'zero is positive' => array( new DecimalValue( 0 ), '+' ),
-			'zero is always positive' => array( new DecimalValue( '-0' ), '+' ),
-			'zero is ALWAYS positive' => array( new DecimalValue( '-0.00' ), '+' ),
-			'+1 is positive' => array( new DecimalValue( '+1' ), '+' ),
-			'-1 is negative' => array( new DecimalValue( '-1' ), '-' ),
-			'+0.01 is positive' => array( new DecimalValue( '+0.01' ), '+' ),
-			'-0.01 is negative' => array( new DecimalValue( '-0.01' ), '-' ),
-		);
+		return [
+			'zero is positive' => [ new DecimalValue( 0 ), '+' ],
+			'zero is always positive' => [ new DecimalValue( '-0' ), '+' ],
+			'zero is ALWAYS positive' => [ new DecimalValue( '-0.00' ), '+' ],
+			'+1 is positive' => [ new DecimalValue( '+1' ), '+' ],
+			'-1 is negative' => [ new DecimalValue( '-1' ), '-' ],
+			'+0.01 is positive' => [ new DecimalValue( '+0.01' ), '+' ],
+			'-0.01 is negative' => [ new DecimalValue( '-0.01' ), '-' ],
+		];
 	}
 
 	/**
@@ -162,30 +162,30 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function getValueProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( 42 ), '+42' );
-		$argLists[] = array( new DecimalValue( -42 ), '-42' );
-		$argLists[] = array( new DecimalValue( -42.0 ), '-42' );
-		$argLists[] = array( new DecimalValue( '-42' ), '-42' );
-		$argLists[] = array( new DecimalValue( 4.5 ), '+4.5' );
-		$argLists[] = array( new DecimalValue( -4.5 ), '-4.5' );
-		$argLists[] = array( new DecimalValue( '+4.2' ), '+4.2' );
-		$argLists[] = array( new DecimalValue( 0 ), '+0' );
-		$argLists[] = array( new DecimalValue( 0.0 ), '+0' );
-		$argLists[] = array( new DecimalValue( 1.0 ), '+1' );
-		$argLists[] = array( new DecimalValue( 0.5 ), '+0.5' );
-		$argLists[] = array( new DecimalValue( '-0.42' ), '-0.42' );
-		$argLists[] = array( new DecimalValue( '-0.0' ), '+0.0' );
-		$argLists[] = array( new DecimalValue( '-0' ), '+0' );
-		$argLists[] = array( new DecimalValue( '+0.0' ), '+0.0' );
-		$argLists[] = array( new DecimalValue( '+0' ), '+0' );
-		$argLists[] = array( new DecimalValue( 2147483649 ), '+2147483649' );
-		$argLists[] = array( new DecimalValue( 1000000000000000 ), '+1000000000000000' );
-		$argLists[] = array(
+		$argLists[] = [ new DecimalValue( 42 ), '+42' ];
+		$argLists[] = [ new DecimalValue( -42 ), '-42' ];
+		$argLists[] = [ new DecimalValue( -42.0 ), '-42' ];
+		$argLists[] = [ new DecimalValue( '-42' ), '-42' ];
+		$argLists[] = [ new DecimalValue( 4.5 ), '+4.5' ];
+		$argLists[] = [ new DecimalValue( -4.5 ), '-4.5' ];
+		$argLists[] = [ new DecimalValue( '+4.2' ), '+4.2' ];
+		$argLists[] = [ new DecimalValue( 0 ), '+0' ];
+		$argLists[] = [ new DecimalValue( 0.0 ), '+0' ];
+		$argLists[] = [ new DecimalValue( 1.0 ), '+1' ];
+		$argLists[] = [ new DecimalValue( 0.5 ), '+0.5' ];
+		$argLists[] = [ new DecimalValue( '-0.42' ), '-0.42' ];
+		$argLists[] = [ new DecimalValue( '-0.0' ), '+0.0' ];
+		$argLists[] = [ new DecimalValue( '-0' ), '+0' ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), '+0.0' ];
+		$argLists[] = [ new DecimalValue( '+0' ), '+0' ];
+		$argLists[] = [ new DecimalValue( 2147483649 ), '+2147483649' ];
+		$argLists[] = [ new DecimalValue( 1000000000000000 ), '+1000000000000000' ];
+		$argLists[] = [
 			new DecimalValue( 1 + 1e-14 / 3 ),
 			'+1.0000000000000033306690738754696212708950042724609375'
-		);
+		];
 
 		return $argLists;
 	}
@@ -199,21 +199,21 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function getValueFloatProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( 42 ), 42.0 );
-		$argLists[] = array( new DecimalValue( -42 ), -42.0 );
-		$argLists[] = array( new DecimalValue( '-42' ), -42.0 );
-		$argLists[] = array( new DecimalValue( 4.5 ), 4.5 );
-		$argLists[] = array( new DecimalValue( -4.5 ), -4.5 );
-		$argLists[] = array( new DecimalValue( '+4.2' ), 4.2 );
-		$argLists[] = array( new DecimalValue( 0 ), 0.0 );
-		$argLists[] = array( new DecimalValue( 0.5 ), 0.5 );
-		$argLists[] = array( new DecimalValue( '-0.42' ), -0.42 );
-		$argLists[] = array( new DecimalValue( '-0.0' ), 0.0 );
-		$argLists[] = array( new DecimalValue( '-0' ), 0.0 );
-		$argLists[] = array( new DecimalValue( '+0.0' ), 0.0 );
-		$argLists[] = array( new DecimalValue( '+0' ), 0.0 );
+		$argLists[] = [ new DecimalValue( 42 ), 42.0 ];
+		$argLists[] = [ new DecimalValue( -42 ), -42.0 ];
+		$argLists[] = [ new DecimalValue( '-42' ), -42.0 ];
+		$argLists[] = [ new DecimalValue( 4.5 ), 4.5 ];
+		$argLists[] = [ new DecimalValue( -4.5 ), -4.5 ];
+		$argLists[] = [ new DecimalValue( '+4.2' ), 4.2 ];
+		$argLists[] = [ new DecimalValue( 0 ), 0.0 ];
+		$argLists[] = [ new DecimalValue( 0.5 ), 0.5 ];
+		$argLists[] = [ new DecimalValue( '-0.42' ), -0.42 ];
+		$argLists[] = [ new DecimalValue( '-0.0' ), 0.0 ];
+		$argLists[] = [ new DecimalValue( '-0' ), 0.0 ];
+		$argLists[] = [ new DecimalValue( '+0.0' ), 0.0 ];
+		$argLists[] = [ new DecimalValue( '+0' ), 0.0 ];
 
 		return $argLists;
 	}
@@ -227,15 +227,15 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function getGetIntegerPartProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), '0' ),
-			array( new DecimalValue( '-0.0' ), '0' ),
-			array( new DecimalValue( '+10' ), '10' ),
-			array( new DecimalValue( '-10' ), '10' ),
-			array( new DecimalValue( '+10.663' ), '10' ),
-			array( new DecimalValue( '-10.001' ), '10' ),
-			array( new DecimalValue( '+0.01' ), '0' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '0' ],
+			[ new DecimalValue( '-0.0' ), '0' ],
+			[ new DecimalValue( '+10' ), '10' ],
+			[ new DecimalValue( '-10' ), '10' ],
+			[ new DecimalValue( '+10.663' ), '10' ],
+			[ new DecimalValue( '-10.001' ), '10' ],
+			[ new DecimalValue( '+0.01' ), '0' ],
+		];
 	}
 
 	/**
@@ -247,14 +247,14 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function getGetFractionalPartProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), '' ),
-			array( new DecimalValue( '-0.0' ), '0' ),
-			array( new DecimalValue( '+10' ), '' ),
-			array( new DecimalValue( '+10.663' ), '663' ),
-			array( new DecimalValue( '-10.001' ), '001' ),
-			array( new DecimalValue( '+0.01' ), '01' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '' ],
+			[ new DecimalValue( '-0.0' ), '0' ],
+			[ new DecimalValue( '+10' ), '' ],
+			[ new DecimalValue( '+10.663' ), '663' ],
+			[ new DecimalValue( '-10.001' ), '001' ],
+			[ new DecimalValue( '+0.01' ), '01' ],
+		];
 	}
 
 	/**
@@ -269,13 +269,13 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function computeComplementProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+0.00' ), '+0.00' ),
-			array( new DecimalValue( '+1' ), '-1' ),
-			array( new DecimalValue( '+100.663' ), '-100.663' ),
-			array( new DecimalValue( '-0.001' ), '+0.001' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+0.00' ), '+0.00' ],
+			[ new DecimalValue( '+1' ), '-1' ],
+			[ new DecimalValue( '+100.663' ), '-100.663' ],
+			[ new DecimalValue( '-0.001' ), '+0.001' ],
+		];
 	}
 
 	/**
@@ -290,15 +290,15 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function computeComputeAbsolute() {
-		return array(
-			array( new DecimalValue( '+0' ), '+0' ),
-			array( new DecimalValue( '+1' ), '+1' ),
-			array( new DecimalValue( '-1' ), '+1' ),
-			array( new DecimalValue( '+100.663' ), '+100.663' ),
-			array( new DecimalValue( '-100.663' ), '+100.663' ),
-			array( new DecimalValue( '+0.001' ), '+0.001' ),
-			array( new DecimalValue( '-0.001' ), '+0.001' ),
-		);
+		return [
+			[ new DecimalValue( '+0' ), '+0' ],
+			[ new DecimalValue( '+1' ), '+1' ],
+			[ new DecimalValue( '-1' ), '+1' ],
+			[ new DecimalValue( '+100.663' ), '+100.663' ],
+			[ new DecimalValue( '-100.663' ), '+100.663' ],
+			[ new DecimalValue( '+0.001' ), '+0.001' ],
+			[ new DecimalValue( '-0.001' ), '+0.001' ],
+		];
 	}
 
 	/**
@@ -310,14 +310,14 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function isZeroProvider() {
-		return array(
-			array( new DecimalValue( '+0' ), true ),
-			array( new DecimalValue( '-0.00' ), true ),
+		return [
+			[ new DecimalValue( '+0' ), true ],
+			[ new DecimalValue( '-0.00' ), true ],
 
-			array( new DecimalValue( '+1' ),       false ),
-			array( new DecimalValue( '+100.663' ), false ),
-			array( new DecimalValue( '-0.001' ),   false ),
-		);
+			[ new DecimalValue( '+1' ),       false ],
+			[ new DecimalValue( '+100.663' ), false ],
+			[ new DecimalValue( '-0.001' ),   false ],
+		];
 	}
 
 	/**
@@ -329,18 +329,18 @@ class DecimalValueTest extends DataValueTest {
 	}
 
 	public function provideGetTrim() {
-		return array(
-			array( new DecimalValue( '+8' ),     new DecimalValue( '+8' ) ),
-			array( new DecimalValue( '+80' ),    new DecimalValue( '+80' ) ),
-			array( new DecimalValue( '+800' ),   new DecimalValue( '+800' ) ),
-			array( new DecimalValue( '+0' ),     new DecimalValue( '+0' ) ),
-			array( new DecimalValue( '+0.0' ),   new DecimalValue( '+0' ) ),
-			array( new DecimalValue( '+10.00' ), new DecimalValue( '+10' ) ),
-			array( new DecimalValue( '-0.1' ),   new DecimalValue( '-0.1' ) ),
-			array( new DecimalValue( '-0.10' ),  new DecimalValue( '-0.1' ) ),
-			array( new DecimalValue( '-0.010' ), new DecimalValue( '-0.01' ) ),
-			array( new DecimalValue( '-0.001' ), new DecimalValue( '-0.001' ) ),
-		);
+		return [
+			[ new DecimalValue( '+8' ),     new DecimalValue( '+8' ) ],
+			[ new DecimalValue( '+80' ),    new DecimalValue( '+80' ) ],
+			[ new DecimalValue( '+800' ),   new DecimalValue( '+800' ) ],
+			[ new DecimalValue( '+0' ),     new DecimalValue( '+0' ) ],
+			[ new DecimalValue( '+0.0' ),   new DecimalValue( '+0' ) ],
+			[ new DecimalValue( '+10.00' ), new DecimalValue( '+10' ) ],
+			[ new DecimalValue( '-0.1' ),   new DecimalValue( '-0.1' ) ],
+			[ new DecimalValue( '-0.10' ),  new DecimalValue( '-0.1' ) ],
+			[ new DecimalValue( '-0.010' ), new DecimalValue( '-0.01' ) ],
+			[ new DecimalValue( '-0.001' ), new DecimalValue( '-0.001' ) ],
+		];
 	}
 
 }

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -27,23 +27,23 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( '+42' ), '1', new DecimalValue( '+42' ), new DecimalValue( '+42' ) );
-		$argLists[] = array( new DecimalValue( '+0.01' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '+0.0001' ) );
-		$argLists[] = array( new DecimalValue( '-0.5' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '-0.7' ) );
+		$argLists[] = [ new DecimalValue( '+42' ), '1', new DecimalValue( '+42' ), new DecimalValue( '+42' ) ];
+		$argLists[] = [ new DecimalValue( '+0.01' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '+0.0001' ) ];
+		$argLists[] = [ new DecimalValue( '-0.5' ), '1', new DecimalValue( '+0.02' ), new DecimalValue( '-0.7' ) ];
 
 		return $argLists;
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( '+0' ), '', new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
-		$argLists[] = array( new DecimalValue( '+0' ), 1, new DecimalValue( '+0' ), new DecimalValue( '+0' ) );
+		$argLists[] = [ new DecimalValue( '+0' ), '', new DecimalValue( '+0' ), new DecimalValue( '+0' ) ];
+		$argLists[] = [ new DecimalValue( '+0' ), 1, new DecimalValue( '+0' ), new DecimalValue( '+0' ) ];
 
-		$argLists[] = array( new DecimalValue( '+0' ), '1', new DecimalValue( '-0.001' ), new DecimalValue( '-1' ) );
-		$argLists[] = array( new DecimalValue( '+0' ), '1', new DecimalValue( '+1' ), new DecimalValue( '+0.001' ) );
+		$argLists[] = [ new DecimalValue( '+0' ), '1', new DecimalValue( '-0.001' ), new DecimalValue( '-1' ) ];
+		$argLists[] = [ new DecimalValue( '+0' ), '1', new DecimalValue( '+1' ), new DecimalValue( '+0.001' ) ];
 
 		return $argLists;
 	}
@@ -95,36 +95,36 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function newFromNumberProvider() {
-		return array(
-			array(
+		return [
+			[
 				42, '1', null, null,
 				new QuantityValue( new DecimalValue( '+42' ), '1', new DecimalValue( '+42' ), new DecimalValue( '+42' ) )
-			),
-			array(
+			],
+			[
 				-0.05, '1', null, null,
 				new QuantityValue( new DecimalValue( '-0.05' ), '1', new DecimalValue( '-0.05' ), new DecimalValue( '-0.05' ) )
-			),
-			array(
+			],
+			[
 				0, 'm', 0.5, -0.5,
 				new QuantityValue( new DecimalValue( '+0' ), 'm', new DecimalValue( '+0.5' ), new DecimalValue( '-0.5' ) )
-			),
-			array(
+			],
+			[
 				'+23', '1', null, null,
 				new QuantityValue( new DecimalValue( '+23' ), '1', new DecimalValue( '+23' ), new DecimalValue( '+23' ) )
-			),
-			array(
+			],
+			[
 				'+42', '1', '+43', '+41',
 				new QuantityValue( new DecimalValue( '+42' ), '1', new DecimalValue( '+43' ), new DecimalValue( '+41' ) )
-			),
-			array(
+			],
+			[
 				'-0.05', 'm', '-0.04', '-0.06',
 				new QuantityValue( new DecimalValue( '-0.05' ), 'm', new DecimalValue( '-0.04' ), new DecimalValue( '-0.06' ) )
-			),
-			array(
+			],
+			[
 				new DecimalValue( '+42' ), '1', new DecimalValue( 43 ), new DecimalValue( 41.0 ),
 				new QuantityValue( new DecimalValue( '+42' ), '1', new DecimalValue( 43 ), new DecimalValue( 41.0 ) )
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -136,33 +136,33 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function validArraySerializationProvider() {
-		return array(
-			'complete' => array(
-				array(
+		return [
+			'complete' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
-				),
+				],
 				QuantityValue::newFromNumber( '+2', '1', '+2.5', '+1.5' )
-			),
-			'unbounded' => array(
-				array(
+			],
+			'unbounded' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
-				),
+				],
 				UnboundedQuantityValue::newFromNumber( '+2', '1' )
-			),
-			'unbounded with existing array keys' => array(
-				array(
+			],
+			'unbounded with existing array keys' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => null,
 					'lowerBound' => null,
-				),
+				],
 				UnboundedQuantityValue::newFromNumber( '+2', '1' )
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -174,60 +174,60 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function invalidArraySerializationProvider() {
-		return array(
-			'no-amount' => array(
-				array(
+		return [
+			'no-amount' => [
+				[
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'no-unit' => array(
-				array(
+				]
+			],
+			'no-unit' => [
+				[
 					'amount' => '+2',
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'no-upperBound' => array(
-				array(
+				]
+			],
+			'no-upperBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'no-lowerBound' => array(
-				array(
+				]
+			],
+			'no-lowerBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
-				)
-			),
-			'bad-amount' => array(
-				array(
+				]
+			],
+			'bad-amount' => [
+				[
 					'amount' => 'x',
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'bad-upperBound' => array(
-				array(
+				]
+			],
+			'bad-upperBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => 'x',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'bad-lowerBound' => array(
-				array(
+				]
+			],
+			'bad-lowerBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => 'x',
-				)
-			),
-		);
+				]
+			],
+		];
 	}
 
 	/**
@@ -235,19 +235,19 @@ class QuantityValueTest extends DataValueTest {
 	 * @see http://www.regular-expressions.info/anchors.html#realend
 	 */
 	public function testTrailingNewlineRobustness() {
-		$value = QuantityValue::newFromArray( array(
+		$value = QuantityValue::newFromArray( [
 			'amount' => "-0.0\n",
 			'unit' => "1\n",
 			'upperBound' => "-0.0\n",
 			'lowerBound' => "-0.0\n",
-		) );
+		] );
 
-		$this->assertSame( array(
+		$this->assertSame( [
 			'amount' => '+0.0',
 			'unit' => "1\n",
 			'upperBound' => '+0.0',
 			'lowerBound' => '+0.0',
-		), $value->getArrayValue() );
+		], $value->getArrayValue() );
 	}
 
 	/**
@@ -265,18 +265,18 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function getUncertaintyProvider() {
-		return array(
-			array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0.0 ),
+		return [
+			[ QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), 0.0 ],
 
-			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2.0 ),
-			array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), 0.02 ),
-			array( QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2.0 ),
-			array( QuantityValue::newFromNumber( '+100.0', '1', '+100.1', '+99.9' ), 0.2 ),
-			array( QuantityValue::newFromNumber( '+12.34', '1', '+12.35', '+12.33' ), 0.02 ),
+			[ QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), 2.0 ],
+			[ QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), 0.02 ],
+			[ QuantityValue::newFromNumber( '+100', '1', '+101', '+99' ), 2.0 ],
+			[ QuantityValue::newFromNumber( '+100.0', '1', '+100.1', '+99.9' ), 0.2 ],
+			[ QuantityValue::newFromNumber( '+12.34', '1', '+12.35', '+12.33' ), 0.02 ],
 
-			array( QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), 0.8 ),
-			array( QuantityValue::newFromNumber( '+7.3', '1', '+7.7', '+5.2' ), 2.5 ),
-		);
+			[ QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), 0.8 ],
+			[ QuantityValue::newFromNumber( '+7.3', '1', '+7.7', '+5.2' ), 2.5 ],
+		];
 	}
 
 	/**
@@ -287,16 +287,16 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function getUncertaintyMarginProvider() {
-		return array(
-			array( QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), '+1' ),
-			array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), '+0.01' ),
+		return [
+			[ QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ), '+1' ],
+			[ QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), '+0.01' ],
 
-			array( QuantityValue::newFromNumber( '-1', '1', '-1', '-1' ), '+0' ),
+			[ QuantityValue::newFromNumber( '-1', '1', '-1', '-1' ), '+0' ],
 
-			array( QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), '+0.6' ),
-			array( QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2.0' ),
-			array( QuantityValue::newFromNumber( '+11.5', '1', '+15', '+10.5' ), '+3.5' ),
-		);
+			[ QuantityValue::newFromNumber( '+0', '1', '+0.2', '-0.6' ), '+0.6' ],
+			[ QuantityValue::newFromNumber( '+7.5', '1', '+7.5', '+5.5' ), '+2.0' ],
+			[ QuantityValue::newFromNumber( '+11.5', '1', '+15', '+10.5' ), '+3.5' ],
+		];
 	}
 
 	/**
@@ -307,23 +307,23 @@ class QuantityValueTest extends DataValueTest {
 	}
 
 	public function getOrderOfUncertaintyProvider() {
-		return array(
-			0 => array( QuantityValue::newFromNumber( '+0' ), 0 ),
-			1 => array( QuantityValue::newFromNumber( '-123' ), 0 ),
-			2 => array( QuantityValue::newFromNumber( '-1.23' ), -2 ),
+		return [
+			0 => [ QuantityValue::newFromNumber( '+0' ), 0 ],
+			1 => [ QuantityValue::newFromNumber( '-123' ), 0 ],
+			2 => [ QuantityValue::newFromNumber( '-1.23' ), -2 ],
 
-			10 => array( QuantityValue::newFromNumber( '-100', '1', '-99', '-101' ), 0 ),
-			11 => array( QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), -2 ),
-			12 => array( QuantityValue::newFromNumber( '-117.3', '1', '-117.2', '-117.4' ), -1 ),
+			10 => [ QuantityValue::newFromNumber( '-100', '1', '-99', '-101' ), 0 ],
+			11 => [ QuantityValue::newFromNumber( '+0.00', '1', '+0.01', '-0.01' ), -2 ],
+			12 => [ QuantityValue::newFromNumber( '-117.3', '1', '-117.2', '-117.4' ), -1 ],
 
-			20 => array( QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.97' ), -2 ),
-			21 => array( QuantityValue::newFromNumber( '-0.002', '1', '-0.001', '-0.004' ), -3 ),
-			22 => array( QuantityValue::newFromNumber( '-0.002', '1', '+0.001', '-0.06' ), -3 ),
-			23 => array( QuantityValue::newFromNumber( '-21', '1', '+1.1', '-120' ), 1 ),
-			24 => array( QuantityValue::newFromNumber( '-2', '1', '+1.1', '-120' ), 0 ),
-			25 => array( QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900.03' ), 1 ),
-			26 => array( QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900' ), 2 ),
-		);
+			20 => [ QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.97' ), -2 ],
+			21 => [ QuantityValue::newFromNumber( '-0.002', '1', '-0.001', '-0.004' ), -3 ],
+			22 => [ QuantityValue::newFromNumber( '-0.002', '1', '+0.001', '-0.06' ), -3 ],
+			23 => [ QuantityValue::newFromNumber( '-21', '1', '+1.1', '-120' ), 1 ],
+			24 => [ QuantityValue::newFromNumber( '-2', '1', '+1.1', '-120' ), 0 ],
+			25 => [ QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900.03' ), 1 ],
+			26 => [ QuantityValue::newFromNumber( '+1000', '1', '+1100', '+900' ), 2 ],
+		];
 	}
 
 	/**
@@ -333,8 +333,8 @@ class QuantityValueTest extends DataValueTest {
 		$args = func_get_args();
 		$extraArgs = array_slice( $args, 3 );
 
-		$call = array( $quantity, 'transform' );
-		$callArgs = array_merge( array( 'x', $transformation ), $extraArgs );
+		$call = [ $quantity, 'transform' ];
+		$callArgs = array_merge( [ 'x', $transformation ], $extraArgs );
 		$actual = call_user_func_array( $call, $callArgs );
 
 		$this->assertSame( 'x', $actual->getUnit() );
@@ -357,62 +357,62 @@ class QuantityValueTest extends DataValueTest {
 			return new DecimalValue( $value->getValueFloat() * $factor );
 		};
 
-		return array(
-			0 => array(
+		return [
+			0 => [
 				QuantityValue::newFromNumber( '+10', '1', '+11', '+9' ),
 				$identity,
 				QuantityValue::newFromNumber( '+10', '?', '+11', '+9' )
-			),
-			1 => array(
+			],
+			1 => [
 				QuantityValue::newFromNumber( '-0.5', '1', '-0.4', '-0.6' ),
 				$identity,
 				QuantityValue::newFromNumber( '-0.5', '?', '-0.4', '-0.6' )
-			),
-			2 => array(
+			],
+			2 => [
 				QuantityValue::newFromNumber( '+0', '1', '+1', '-1' ),
 				$square,
 				QuantityValue::newFromNumber( '+0', '?', '+1', '-1' )
-			),
-			3 => array(
+			],
+			3 => [
 				QuantityValue::newFromNumber( '+10', '1', '+11', '+9' ),
 				$square,
 				// note how rounding applies to bounds
 				QuantityValue::newFromNumber( '+1000', '?', '+1300', '+700' )
-			),
-			4 => array(
+			],
+			4 => [
 				QuantityValue::newFromNumber( '+0.5', '1', '+0.6', '+0.4' ),
 				$scale,
 				QuantityValue::newFromNumber( '+0.25', '?', '+0.30', '+0.20' ),
 				0.5
-			),
+			],
 
 			// note: absolutely exact values require conversion with infinite precision!
-			10 => array(
+			10 => [
 				QuantityValue::newFromNumber( '+100', '1', '+100', '+100' ),
 				$scale,
 				QuantityValue::newFromNumber( '+12825', '?', '+12825', '+12825' ),
 				128.25
-			),
+			],
 
-			11 => array(
+			11 => [
 				QuantityValue::newFromNumber( '+100', '1', '+110', '+90' ),
 				$scale,
 				QuantityValue::newFromNumber( '+330', '?', '+370', '+300' ),
 				3.3333
-			),
-			12 => array(
+			],
+			12 => [
 				QuantityValue::newFromNumber( '+100', '1', '+100.1', '+99.9' ),
 				$scale,
 				QuantityValue::newFromNumber( '+333.3', '?', '+333.7', '+333.0' ),
 				3.3333
-			),
-			13 => array(
+			],
+			13 => [
 				QuantityValue::newFromNumber( '+100', '1', '+100.01', '+99.99' ),
 				$scale,
 				QuantityValue::newFromNumber( '+333.33', '?', '+333.36', '+333.30' ),
 				3.3333
-			),
-		);
+			],
+		];
 	}
 
 }

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -27,20 +27,20 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( '+42' ), '1' );
-		$argLists[] = array( new DecimalValue( '+0.01' ), '1' );
-		$argLists[] = array( new DecimalValue( '-0.5' ), '1' );
+		$argLists[] = [ new DecimalValue( '+42' ), '1' ];
+		$argLists[] = [ new DecimalValue( '+0.01' ), '1' ];
+		$argLists[] = [ new DecimalValue( '-0.5' ), '1' ];
 
 		return $argLists;
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$argLists[] = array( new DecimalValue( '+0' ), '' );
-		$argLists[] = array( new DecimalValue( '+0' ), 1 );
+		$argLists[] = [ new DecimalValue( '+0' ), '' ];
+		$argLists[] = [ new DecimalValue( '+0' ), 1 ];
 
 		return $argLists;
 	}
@@ -76,36 +76,36 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	}
 
 	public function newFromNumberProvider() {
-		return array(
-			array(
+		return [
+			[
 				42, '1',
 				new UnboundedQuantityValue( new DecimalValue( '+42' ), '1' )
-			),
-			array(
+			],
+			[
 				-0.05, '1',
 				new UnboundedQuantityValue( new DecimalValue( '-0.05' ), '1' )
-			),
-			array(
+			],
+			[
 				0, 'm',
 				new UnboundedQuantityValue( new DecimalValue( '+0' ), 'm' )
-			),
-			array(
+			],
+			[
 				'+23', '1',
 				new UnboundedQuantityValue( new DecimalValue( '+23' ), '1' )
-			),
-			array(
+			],
+			[
 				'+42', '1',
 				new UnboundedQuantityValue( new DecimalValue( '+42' ), '1' )
-			),
-			array(
+			],
+			[
 				'-0.05', 'm',
 				new UnboundedQuantityValue( new DecimalValue( '-0.05' ), 'm' )
-			),
-			array(
+			],
+			[
 				new DecimalValue( '+42' ), '1',
 				new UnboundedQuantityValue( new DecimalValue( '+42' ), '1' )
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -117,33 +117,33 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	}
 
 	public function validArraySerializationProvider() {
-		return array(
-			'unbounded' => array(
-				array(
+		return [
+			'unbounded' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
-				),
+				],
 				UnboundedQuantityValue::newFromNumber( '+2', '1' )
-			),
-			'unbounded with existing array keys' => array(
-				array(
+			],
+			'unbounded with existing array keys' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => null,
 					'lowerBound' => null,
-				),
+				],
 				UnboundedQuantityValue::newFromNumber( '+2', '1' )
-			),
-			'with-extra' => array(
-				array(
+			],
+			'with-extra' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => '+1.5',
-				),
+				],
 				QuantityValue::newFromNumber( '+2', '1', '+2.5', '+1.5' )
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -155,54 +155,54 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	}
 
 	public function invalidArraySerializationProvider() {
-		return array(
-			'no-amount' => array(
-				array(
+		return [
+			'no-amount' => [
+				[
 					'unit' => '1',
-				)
-			),
-			'no-unit' => array(
-				array(
+				]
+			],
+			'no-unit' => [
+				[
 					'amount' => '+2',
-				)
-			),
-			'no-upperBound' => array(
-				array(
+				]
+			],
+			'no-upperBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'no-lowerBound' => array(
-				array(
+				]
+			],
+			'no-lowerBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
-				)
-			),
-			'bad-amount' => array(
-				array(
+				]
+			],
+			'bad-amount' => [
+				[
 					'amount' => 'x',
 					'unit' => '1',
-				)
-			),
-			'bad-upperBound' => array(
-				array(
+				]
+			],
+			'bad-upperBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => 'x',
 					'lowerBound' => '+1.5',
-				)
-			),
-			'bad-lowerBound' => array(
-				array(
+				]
+			],
+			'bad-lowerBound' => [
+				[
 					'amount' => '+2',
 					'unit' => '1',
 					'upperBound' => '+2.5',
 					'lowerBound' => 'x',
-				)
-			),
-		);
+				]
+			],
+		];
 	}
 
 	/**
@@ -210,15 +210,15 @@ class UnboundedQuantityValueTest extends DataValueTest {
 	 * @see http://www.regular-expressions.info/anchors.html#realend
 	 */
 	public function testTrailingNewlineRobustness() {
-		$value = UnboundedQuantityValue::newFromArray( array(
+		$value = UnboundedQuantityValue::newFromArray( [
 			'amount' => "-0.0\n",
 			'unit' => "1\n",
-		) );
+		] );
 
-		$this->assertSame( array(
+		$this->assertSame( [
 			'amount' => '+0.0',
 			'unit' => "1\n",
-		), $value->getArrayValue() );
+		], $value->getArrayValue() );
 	}
 
 	/**
@@ -235,8 +235,8 @@ class UnboundedQuantityValueTest extends DataValueTest {
 		$args = func_get_args();
 		$extraArgs = array_slice( $args, 3 );
 
-		$call = array( $quantity, 'transform' );
-		$callArgs = array_merge( array( 'x', $transformation ), $extraArgs );
+		$call = [ $quantity, 'transform' ];
+		$callArgs = array_merge( [ 'x', $transformation ], $extraArgs );
 		$actual = call_user_func_array( $call, $callArgs );
 
 		$this->assertSame( 'x', $actual->getUnit() );
@@ -257,48 +257,48 @@ class UnboundedQuantityValueTest extends DataValueTest {
 			return new DecimalValue( $value->getValueFloat() * $factor );
 		};
 
-		return array(
-			0 => array(
+		return [
+			0 => [
 				UnboundedQuantityValue::newFromNumber( '+10', '1' ),
 				$identity,
 				UnboundedQuantityValue::newFromNumber( '+10', '?' )
-			),
-			1 => array(
+			],
+			1 => [
 				UnboundedQuantityValue::newFromNumber( '-0.5', '1' ),
 				$identity,
 				UnboundedQuantityValue::newFromNumber( '-0.5', '?' )
-			),
-			2 => array(
+			],
+			2 => [
 				UnboundedQuantityValue::newFromNumber( '+0', '1' ),
 				$square,
 				UnboundedQuantityValue::newFromNumber( '+0', '?' )
-			),
-			3 => array(
+			],
+			3 => [
 				UnboundedQuantityValue::newFromNumber( '+10', '1' ),
 				$square,
 				UnboundedQuantityValue::newFromNumber( '+1000', '?' )
-			),
-			4 => array(
+			],
+			4 => [
 				UnboundedQuantityValue::newFromNumber( '+0.5', '1' ),
 				$scale,
 				UnboundedQuantityValue::newFromNumber( '+0.25', '?' ),
 				0.5
-			),
+			],
 
 			// note: absolutely exact values require conversion with infinite precision!
-			10 => array(
+			10 => [
 				UnboundedQuantityValue::newFromNumber( '+100', '1' ),
 				$scale,
 				UnboundedQuantityValue::newFromNumber( '+12825', '?' ),
 				128.25
-			),
-			13 => array(
+			],
+			13 => [
 				UnboundedQuantityValue::newFromNumber( '+100', '1' ),
 				$scale,
 				UnboundedQuantityValue::newFromNumber( '+333.33', '?' ),
 				3.3333
-			),
-		);
+			],
+		];
 	}
 
 }

--- a/tests/ValueFormatters/BasicNumberLocalizerTest.php
+++ b/tests/ValueFormatters/BasicNumberLocalizerTest.php
@@ -16,18 +16,18 @@ use ValueFormatters\BasicNumberLocalizer;
 class BasicNumberLocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function provideLocalizeNumber() {
-		return array(
-			array( '5', '5' ),
-			array( '+3', '+3' ),
-			array( '-15', '-15' ),
+		return [
+			[ '5', '5' ],
+			[ '+3', '+3' ],
+			[ '-15', '-15' ],
 
-			array( '5.3', '5.3' ),
-			array( '+3.2', '+3.2' ),
-			array( '-15.77', '-15.77' ),
+			[ '5.3', '5.3' ],
+			[ '+3.2', '+3.2' ],
+			[ '-15.77', '-15.77' ],
 
-			array( 77, '77' ),
-			array( -7.7, '-7.7' ),
-		);
+			[ 77, '77' ],
+			[ -7.7, '-7.7' ],
+		];
 	}
 
 	/**

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -40,24 +40,24 @@ class DecimalFormatterTest extends ValueFormatterTestBase {
 	 * @see ValueFormatterTestBase::validProvider
 	 */
 	public function validProvider() {
-		$optionsForceSign = new FormatterOptions( array(
+		$optionsForceSign = new FormatterOptions( [
 			DecimalFormatter::OPT_FORCE_SIGN => true
-		) );
+		] );
 
-		$decimals = array(
-			'+0' => array( '0', null ),
-			'+0.0' => array( '0.0', null ),
-			'-0.0130' => array( '-0.0130', null ),
-			'+10000.013' => array( '10000.013', null ),
-			'+20000.4' => array( '+20000.4', $optionsForceSign ),
-			'-12' => array( '-12', null )
-		);
+		$decimals = [
+			'+0' => [ '0', null ],
+			'+0.0' => [ '0.0', null ],
+			'-0.0130' => [ '-0.0130', null ],
+			'+10000.013' => [ '10000.013', null ],
+			'+20000.4' => [ '+20000.4', $optionsForceSign ],
+			'-12' => [ '-12', null ]
+		];
 
-		$argLists = array();
+		$argLists = [];
 		foreach ( $decimals as $input => $args ) {
 			$inputValue = new DecimalValue( $input );
 
-			$argLists[$input] = array_merge( array( $inputValue ), $args );
+			$argLists[$input] = array_merge( [ $inputValue ], $args );
 		}
 
 		return $argLists;

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -67,117 +67,117 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 	 * @see ValueFormatterTestBase::validProvider
 	 */
 	public function validProvider() {
-		$noMargin = new FormatterOptions( array(
+		$noMargin = new FormatterOptions( [
 			QuantityFormatter::OPT_SHOW_UNCERTAINTY_MARGIN => false
-		) );
+		] );
 
-		$withMargin = new FormatterOptions( array(
+		$withMargin = new FormatterOptions( [
 			QuantityFormatter::OPT_SHOW_UNCERTAINTY_MARGIN => true
-		) );
+		] );
 
-		$noRounding = new FormatterOptions( array(
+		$noRounding = new FormatterOptions( [
 			QuantityFormatter::OPT_SHOW_UNCERTAINTY_MARGIN => true,
 			QuantityFormatter::OPT_APPLY_ROUNDING => false
-		) );
+		] );
 
-		$exactRounding = new FormatterOptions( array(
+		$exactRounding = new FormatterOptions( [
 			QuantityFormatter::OPT_SHOW_UNCERTAINTY_MARGIN => false,
 			QuantityFormatter::OPT_APPLY_ROUNDING => -2
-		) );
+		] );
 
-		$forceSign = new FormatterOptions( array(
+		$forceSign = new FormatterOptions( [
 			QuantityFormatter::OPT_SHOW_UNCERTAINTY_MARGIN => false,
 			DecimalFormatter::OPT_FORCE_SIGN => true,
-		) );
+		] );
 
-		$noUnit = new FormatterOptions( array(
+		$noUnit = new FormatterOptions( [
 			QuantityFormatter::OPT_APPLY_UNIT => false,
-		) );
+		] );
 
-		return array(
-			'+0/nm' => array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0', $noMargin ),
-			'+0/wm' => array( QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0±0', $withMargin ),
+		return [
+			'+0/nm' => [ QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0', $noMargin ],
+			'+0/wm' => [ QuantityValue::newFromNumber( '+0', '1', '+0', '+0' ), '0±0', $withMargin ],
 
-			'+0.0/nm' => array( QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0.0 °', $noMargin ),
-			'+0.0/wm' => array( QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0±0.1 °', $withMargin ),
-			'+0.0/xr' => array( QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0.0 °', $exactRounding ),
+			'+0.0/nm' => [ QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0.0 °', $noMargin ],
+			'+0.0/wm' => [ QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0±0.1 °', $withMargin ],
+			'+0.0/xr' => [ QuantityValue::newFromNumber( '+0.0', '°', '+0.1', '-0.1' ), '0.0 °', $exactRounding ],
 
-			'-1205/nm' => array( QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1200 m', $noMargin ),
-			'-1205/wm' => array( QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100 m', $withMargin ),
-			'-1205/nr' => array( QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100 m', $noRounding ),
-			'-1205/xr' => array( QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205 m', $exactRounding ),
-			'-1205/nu' => array( QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100', $noUnit ),
+			'-1205/nm' => [ QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1200 m', $noMargin ],
+			'-1205/wm' => [ QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100 m', $withMargin ],
+			'-1205/nr' => [ QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100 m', $noRounding ],
+			'-1205/xr' => [ QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205 m', $exactRounding ],
+			'-1205/nu' => [ QuantityValue::newFromNumber( '-1205', 'm', '-1105', '-1305' ), '-1205±100', $noUnit ],
 
-			'+3.025/nm' => array( QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.025', $noMargin ),
-			'+3.025/wm' => array( QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.025±0.0039', $withMargin ),
-			'+3.025/xr' => array( QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.03', $exactRounding ),
+			'+3.025/nm' => [ QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.025', $noMargin ],
+			'+3.025/wm' => [ QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.025±0.0039', $withMargin ],
+			'+3.025/xr' => [ QuantityValue::newFromNumber( '+3.025', '1', '+3.02744', '+3.0211' ), '3.03', $exactRounding ],
 
-			'+3.125/nr' => array( QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '3.125±0.125', $noRounding ),
-			'+3.125/xr' => array( QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '3.13', $exactRounding ),
+			'+3.125/nr' => [ QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '3.125±0.125', $noRounding ],
+			'+3.125/xr' => [ QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '3.13', $exactRounding ],
 
-			'+3.125/fs' => array( QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '+3.13', $forceSign ),
+			'+3.125/fs' => [ QuantityValue::newFromNumber( '+3.125', '1', '+3.2', '+3.0' ), '+3.13', $forceSign ],
 
 			// Unbounded quantities with different options
-			'UB: +0.0/nm' => array( UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $noMargin ),
-			'UB: +0.0/wm' => array( UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $withMargin ),
-			'UB: +0.0/xr' => array( UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $exactRounding ),
-			'UB: +5.021/nm' => array( UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.021 °', $noMargin ),
-			'UB: +5.021/wm' => array( UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.021 °', $withMargin ),
-			'UB: +5.021/xr' => array( UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.02 °', $exactRounding ),
-			'UB: +3.125/fs' => array( UnboundedQuantityValue::newFromNumber( '+3.125', '1' ), '+3.125', $forceSign ),
+			'UB: +0.0/nm' => [ UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $noMargin ],
+			'UB: +0.0/wm' => [ UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $withMargin ],
+			'UB: +0.0/xr' => [ UnboundedQuantityValue::newFromNumber( '+0.0', '°' ), '0.0 °', $exactRounding ],
+			'UB: +5.021/nm' => [ UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.021 °', $noMargin ],
+			'UB: +5.021/wm' => [ UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.021 °', $withMargin ],
+			'UB: +5.021/xr' => [ UnboundedQuantityValue::newFromNumber( '+5.021', '°' ), '5.02 °', $exactRounding ],
+			'UB: +3.125/fs' => [ UnboundedQuantityValue::newFromNumber( '+3.125', '1' ), '+3.125', $forceSign ],
 
 			// Unbounded quantities with enforced, exact rounding
-			array( UnboundedQuantityValue::newFromNumber( '+0.00155', '1' ), '0.00', $exactRounding ),
-			array( UnboundedQuantityValue::newFromNumber( '+0.0155', '1' ), '0.02', $exactRounding ),
-			array( UnboundedQuantityValue::newFromNumber( '+0.155', '1' ), '0.16', $exactRounding ),
-			array( UnboundedQuantityValue::newFromNumber( '+1.55', '1' ), '1.55', $exactRounding ),
-			array( UnboundedQuantityValue::newFromNumber( '+15.5', '1' ), '15.5', $exactRounding ),
-			array( UnboundedQuantityValue::newFromNumber( '+155', '1' ), '155', $exactRounding ),
+			[ UnboundedQuantityValue::newFromNumber( '+0.00155', '1' ), '0.00', $exactRounding ],
+			[ UnboundedQuantityValue::newFromNumber( '+0.0155', '1' ), '0.02', $exactRounding ],
+			[ UnboundedQuantityValue::newFromNumber( '+0.155', '1' ), '0.16', $exactRounding ],
+			[ UnboundedQuantityValue::newFromNumber( '+1.55', '1' ), '1.55', $exactRounding ],
+			[ UnboundedQuantityValue::newFromNumber( '+15.5', '1' ), '15.5', $exactRounding ],
+			[ UnboundedQuantityValue::newFromNumber( '+155', '1' ), '155', $exactRounding ],
 
 			// Default options with different margins
-			'24+-000.01' => array( QuantityValue::newFromNumber( '+24', '1', '+24.01', '+23.99' ), '24±0.01' ),
-			'24+-000.10' => array( QuantityValue::newFromNumber( '+24', '1', '+24.1', '+23.9' ), '24±0.1' ),
-			'24+-001.00' => array( QuantityValue::newFromNumber( '+24', '1', '+25', '+23' ), '24±1' ),
-			'24+-010.00' => array( QuantityValue::newFromNumber( '+24', '1', '+34', '+14' ), '24±10' ),
-			'24+-100.00' => array( QuantityValue::newFromNumber( '+24', '1', '+124', '-76' ), '24±100' ),
+			'24+-000.01' => [ QuantityValue::newFromNumber( '+24', '1', '+24.01', '+23.99' ), '24±0.01' ],
+			'24+-000.10' => [ QuantityValue::newFromNumber( '+24', '1', '+24.1', '+23.9' ), '24±0.1' ],
+			'24+-001.00' => [ QuantityValue::newFromNumber( '+24', '1', '+25', '+23' ), '24±1' ],
+			'24+-010.00' => [ QuantityValue::newFromNumber( '+24', '1', '+34', '+14' ), '24±10' ],
+			'24+-100.00' => [ QuantityValue::newFromNumber( '+24', '1', '+124', '-76' ), '24±100' ],
 
 			// Rounding with a fixed +/-1 margin
-			array( QuantityValue::newFromNumber( '+1.44', '1', '+2.44', '+0.44' ), '1', $noMargin ),
-			array( QuantityValue::newFromNumber( '+1.45', '1', '+2.45', '+0.45' ), '1', $noMargin ),
-			array( QuantityValue::newFromNumber( '+1.49', '1', '+2.49', '+0.49' ), '1', $noMargin ),
-			array( QuantityValue::newFromNumber( '+1.50', '1', '+2.50', '+0.50' ), '2', $noMargin ),
-			array( QuantityValue::newFromNumber( '+2.50', '1', '+3.50', '+1.50' ), '3', $noMargin ),
+			[ QuantityValue::newFromNumber( '+1.44', '1', '+2.44', '+0.44' ), '1', $noMargin ],
+			[ QuantityValue::newFromNumber( '+1.45', '1', '+2.45', '+0.45' ), '1', $noMargin ],
+			[ QuantityValue::newFromNumber( '+1.49', '1', '+2.49', '+0.49' ), '1', $noMargin ],
+			[ QuantityValue::newFromNumber( '+1.50', '1', '+2.50', '+0.50' ), '2', $noMargin ],
+			[ QuantityValue::newFromNumber( '+2.50', '1', '+3.50', '+1.50' ), '3', $noMargin ],
 
 			// Rounding with different margins
-			'1.55+/-0.09' => array( QuantityValue::newFromNumber( '+1.55', '1', '+1.64', '+1.46' ), '1.55', $noMargin ),
-			'1.55+/-0.1' => array( QuantityValue::newFromNumber( '+1.55', '1', '+1.65', '+1.45' ), '1.6', $noMargin ),
-			'1.55+/-0.49' => array( QuantityValue::newFromNumber( '+1.55', '1', '+2.04', '+1.06' ), '1.6', $noMargin ),
-			'1.55+/-0.5' => array( QuantityValue::newFromNumber( '+1.55', '1', '+2.05', '+1.05' ), '1.6', $noMargin ),
-			'1.55+/-0.99' => array( QuantityValue::newFromNumber( '+1.55', '1', '+2.54', '+0.56' ), '1.6', $noMargin ),
-			'1.55+/-1' => array( QuantityValue::newFromNumber( '+1.55', '1', '+2.55', '+0.55' ), '2', $noMargin ),
+			'1.55+/-0.09' => [ QuantityValue::newFromNumber( '+1.55', '1', '+1.64', '+1.46' ), '1.55', $noMargin ],
+			'1.55+/-0.1' => [ QuantityValue::newFromNumber( '+1.55', '1', '+1.65', '+1.45' ), '1.6', $noMargin ],
+			'1.55+/-0.49' => [ QuantityValue::newFromNumber( '+1.55', '1', '+2.04', '+1.06' ), '1.6', $noMargin ],
+			'1.55+/-0.5' => [ QuantityValue::newFromNumber( '+1.55', '1', '+2.05', '+1.05' ), '1.6', $noMargin ],
+			'1.55+/-0.99' => [ QuantityValue::newFromNumber( '+1.55', '1', '+2.54', '+0.56' ), '1.6', $noMargin ],
+			'1.55+/-1' => [ QuantityValue::newFromNumber( '+1.55', '1', '+2.55', '+0.55' ), '2', $noMargin ],
 			// FIXME: We should probably never round to zero as it is confusing.
-			'1.55+/-10' => array( QuantityValue::newFromNumber( '+1.55', '1', '+11.55', '-8.45' ), '0', $noMargin ),
+			'1.55+/-10' => [ QuantityValue::newFromNumber( '+1.55', '1', '+11.55', '-8.45' ), '0', $noMargin ],
 
 			// Do not mess with the value when the margin is rendered
-			array( QuantityValue::newFromNumber( '+1500', '1', '+2500', '+500' ), '1500±1000' ),
-			array( QuantityValue::newFromNumber( '+2', '1', '+2.005', '+1.995' ), '2±0.005' ),
-			array( QuantityValue::newFromNumber( '+1.5', '1', '+2.5', '+0.5' ), '1.5±1' ),
-			array( QuantityValue::newFromNumber( '+1.0005', '1', '+1.0015', '+0.9995' ), '1.0005±0.001' ),
-			array( QuantityValue::newFromNumber( '+0.0015', '1', '+0.0025', '+0.0005' ), '0.0015±0.001' ),
+			[ QuantityValue::newFromNumber( '+1500', '1', '+2500', '+500' ), '1500±1000' ],
+			[ QuantityValue::newFromNumber( '+2', '1', '+2.005', '+1.995' ), '2±0.005' ],
+			[ QuantityValue::newFromNumber( '+1.5', '1', '+2.5', '+0.5' ), '1.5±1' ],
+			[ QuantityValue::newFromNumber( '+1.0005', '1', '+1.0015', '+0.9995' ), '1.0005±0.001' ],
+			[ QuantityValue::newFromNumber( '+0.0015', '1', '+0.0025', '+0.0005' ), '0.0015±0.001' ],
 
 			/**
 			 * Never mess with the margin
 			 * @see https://phabricator.wikimedia.org/T58892
 			 */
-			array( QuantityValue::newFromNumber( '+2', '1', '+3.5', '+0.5' ), '2±1.5' ),
-			array( QuantityValue::newFromNumber( '+2', '1', '+2.016', '+1.984' ), '2±0.016' ),
-			array( QuantityValue::newFromNumber( '+2', '1', '+2.0015', '+1.9985' ), '2±0.0015' ),
-			array( QuantityValue::newFromNumber( '+0.0015', '1', '+0.003', '+0' ), '0.0015±0.0015' ),
-			array( QuantityValue::newFromNumber( '+2.0011', '1', '+2.0022', '+2' ), '2.0011±0.0011' ),
-			array( QuantityValue::newFromNumber( '+2.0099', '1', '+2.0198', '+2' ), '2.0099±0.0099' ),
+			[ QuantityValue::newFromNumber( '+2', '1', '+3.5', '+0.5' ), '2±1.5' ],
+			[ QuantityValue::newFromNumber( '+2', '1', '+2.016', '+1.984' ), '2±0.016' ],
+			[ QuantityValue::newFromNumber( '+2', '1', '+2.0015', '+1.9985' ), '2±0.0015' ],
+			[ QuantityValue::newFromNumber( '+0.0015', '1', '+0.003', '+0' ), '0.0015±0.0015' ],
+			[ QuantityValue::newFromNumber( '+2.0011', '1', '+2.0022', '+2' ), '2.0011±0.0011' ],
+			[ QuantityValue::newFromNumber( '+2.0099', '1', '+2.0198', '+2' ), '2.0099±0.0099' ],
 
 			// IEEE edge cases
-			array(
+			[
 				QuantityValue::newFromNumber(
 					'+1.00000000000000015',
 					'1',
@@ -185,8 +185,8 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 					'+1.00000000000000005'
 				),
 				'1.00000000000000015±0.0000000000000001'
-			),
-			'0.2 / 3 * 3' => array(
+			],
+			'0.2 / 3 * 3' => [
 				QuantityValue::newFromNumber(
 					'+0.2000000000000000111',
 					'1',
@@ -194,8 +194,8 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 					'+0.2000000000000000111'
 				),
 				'0.2000000000000000111±0'
-			),
-			'8 - 6.4' => array(
+			],
+			'8 - 6.4' => [
 				QuantityValue::newFromNumber(
 					'+1.59999999999999964473',
 					'1',
@@ -203,8 +203,8 @@ class QuantityFormatterTest extends ValueFormatterTestBase {
 					'+1.59999999999999964473'
 				),
 				'1.59999999999999964473±0'
-			),
-		);
+			],
+		];
 	}
 
 	public function testFormatWithFormatString() {

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -88,28 +88,28 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 	 * @see ValueFormatterTestBase::validProvider
 	 */
 	public function validProvider() {
-		return array(
-			'Unbounded, Unit 1' => array(
+		return [
+			'Unbounded, Unit 1' => [
 				UnboundedQuantityValue::newFromNumber( '+2', '1' ),
 				'2'
-			),
-			'Unbounded, String unit' => array(
+			],
+			'Unbounded, String unit' => [
 				UnboundedQuantityValue::newFromNumber( '+2', 'Ultrameter' ),
 				'2 <span class="wb-unit">Ultrameter</span>'
-			),
-			'Unit 1' => array(
+			],
+			'Unit 1' => [
 				QuantityValue::newFromNumber( '+2', '1', '+3', '+1' ),
 				'2±1'
-			),
-			'String unit' => array(
+			],
+			'String unit' => [
 				QuantityValue::newFromNumber( '+2', 'Ultrameter', '+3', '+1' ),
 				'2±1 <span class="wb-unit">Ultrameter</span>'
-			),
-			'HTML injection' => array(
+			],
+			'HTML injection' => [
 				QuantityValue::newFromNumber( '+2', '<b>injection</b>', '+2', '+2' ),
 				'2±0 <span class="wb-unit">&lt;b&gt;injection&lt;/b&gt;</span>'
-			),
-		);
+			],
+		];
 	}
 
 	public function testFormatWithFormatString() {
@@ -141,43 +141,43 @@ class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 		$noUnit = new FormatterOptions();
 		$noUnit->setOption( QuantityHtmlFormatter::OPT_APPLY_UNIT, false );
 
-		return array(
-			'Disabled without unit' => array(
+		return [
+			'Disabled without unit' => [
 				$noUnit,
 				UnboundedQuantityValue::newFromNumber( 2, '1' ),
 				'&lt;b&gt;+2&lt;/b&gt;'
-			),
-			'Disabled with unit' => array(
+			],
+			'Disabled with unit' => [
 				$noUnit,
 				UnboundedQuantityValue::newFromNumber( 2, '<b>m</b>' ),
 				'&lt;b&gt;+2&lt;/b&gt;'
-			),
-			'Default without unit' => array(
+			],
+			'Default without unit' => [
 				null,
 				UnboundedQuantityValue::newFromNumber( 2, '1' ),
 				'&lt;b&gt;+2&lt;/b&gt;'
-			),
-			'Default with unit' => array(
+			],
+			'Default with unit' => [
 				null,
 				UnboundedQuantityValue::newFromNumber( 2, '<b>m</b>' ),
 				'&lt;b&gt;+2&lt;/b&gt; <span class="wb-unit">&lt;b&gt;m&lt;/b&gt;</span>'
-			),
-			'HTML escaping bounded' => array(
+			],
+			'HTML escaping bounded' => [
 				null,
 				$this->newQuantityValue( 'DataValues\QuantityValue' ),
 				'&lt;b&gt;+2&lt;/b&gt;±&lt;b&gt;+2&lt;/b&gt;'
-			),
-			'HTML escaping bounded with uncertainty' => array(
+			],
+			'HTML escaping bounded with uncertainty' => [
 				null,
 				$this->newQuantityValue( 'DataValues\QuantityValue', 1 ),
 				'&lt;b&gt;+2&lt;/b&gt;±&lt;b&gt;+2&lt;/b&gt;'
-			),
-			'HTML escaping unbounded' => array(
+			],
+			'HTML escaping unbounded' => [
 				null,
 				$this->newQuantityValue( 'DataValues\UnboundedQuantityValue' ),
 				'&lt;b&gt;+2&lt;/b&gt;'
-			),
-		);
+			],
+		];
 	}
 
 }

--- a/tests/ValueParsers/BasicNumberUnlocalizerTest.php
+++ b/tests/ValueParsers/BasicNumberUnlocalizerTest.php
@@ -16,33 +16,33 @@ use ValueParsers\BasicNumberUnlocalizer;
 class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function provideUnlocalizeNumber() {
-		return array(
-			array( '5', '5' ),
-			array( '+3', '+3' ),
-			array( '-15', '-15' ),
+		return [
+			[ '5', '5' ],
+			[ '+3', '+3' ],
+			[ '-15', '-15' ],
 
-			array( '5.3', '5.3' ),
-			array( '+3.2', '+3.2' ),
-			array( '-15.77', '-15.77' ),
+			[ '5.3', '5.3' ],
+			[ '+3.2', '+3.2' ],
+			[ '-15.77', '-15.77' ],
 
-			array( '.3', '.3' ),
-			array( '+.2', '+.2' ),
-			array( '-.77', '-.77' ),
+			[ '.3', '.3' ],
+			[ '+.2', '+.2' ],
+			[ '-.77', '-.77' ],
 
-			array( '5.3e4', '5.3e4' ),
-			array( '+3.2E-4', '+3.2E-4' ),
-			array( '-15.77e+4.2', '-15.77e+4.2' ),
+			[ '5.3e4', '5.3e4' ],
+			[ '+3.2E-4', '+3.2E-4' ],
+			[ '-15.77e+4.2', '-15.77e+4.2' ],
 
-			array( '0x20', '0x20' ),
-			array( '0X20', '0X20' ),
+			[ '0x20', '0x20' ],
+			[ '0X20', '0X20' ],
 
-			array( '1,335.3', '1335.3' ),
-			array( '+1,333.2', '+1333.2' ),
-			array( '-1,315.77', '-1315.77' ),
+			[ '1,335.3', '1335.3' ],
+			[ '+1,333.2', '+1333.2' ],
+			[ '-1,315.77', '-1315.77' ],
 
-			array( ' 1,333.3', '1333.3' ),
-			array( '1,333.3 ', '1333.3' ),
-		);
+			[ ' 1,333.3', '1333.3' ],
+			[ '1,333.3 ', '1333.3' ],
+		];
 	}
 
 	/**
@@ -56,27 +56,27 @@ class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function provideGetNumberRegexMatch() {
-		return array(
-			array( '5' ),
-			array( '+3' ),
-			array( '-15' ),
+		return [
+			[ '5' ],
+			[ '+3' ],
+			[ '-15' ],
 
-			array( '5.3' ),
-			array( '+3.2' ),
-			array( '-15.77' ),
+			[ '5.3' ],
+			[ '+3.2' ],
+			[ '-15.77' ],
 
-			array( '.3' ),
-			array( '+.2' ),
-			array( '-.77' ),
+			[ '.3' ],
+			[ '+.2' ],
+			[ '-.77' ],
 
-			array( '5.3e4' ),
-			array( '+3.2E-4' ),
-			array( '-15.77e+2' ),
+			[ '5.3e4' ],
+			[ '+3.2E-4' ],
+			[ '-15.77e+2' ],
 
-			array( '1,335.3' ),
-			array( '+1,333.2' ),
-			array( '-1,315.77' ),
-		);
+			[ '1,335.3' ],
+			[ '+1,333.2' ],
+			[ '-1,315.77' ],
+		];
 	}
 
 	/**
@@ -90,30 +90,30 @@ class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function provideGetNumberRegexMismatch() {
-		return array(
-			array( '' ),
-			array( ' ' ),
-			array( '+' ),
-			array( 'e' ),
+		return [
+			[ '' ],
+			[ ' ' ],
+			[ '+' ],
+			[ 'e' ],
 
-			array( '+.' ),
-			array( '.-' ),
-			array( '...' ),
+			[ '+.' ],
+			[ '.-' ],
+			[ '...' ],
 
-			array( '0x20' ),
-			array( '2x2' ),
-			array( 'x2' ),
-			array( '2x' ),
+			[ '0x20' ],
+			[ '2x2' ],
+			[ 'x2' ],
+			[ '2x' ],
 
-			array( 'e.' ),
-			array( '.e' ),
-			array( '12e' ),
-			array( 'E17' ),
+			[ 'e.' ],
+			[ '.e' ],
+			[ '12e' ],
+			[ 'E17' ],
 
-			array( '+-3' ),
-			array( '++7' ),
-			array( '--5' ),
-		);
+			[ '+-3' ],
+			[ '++7' ],
+			[ '--5' ],
+		];
 	}
 
 	/**
@@ -127,9 +127,9 @@ class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function provideGetUnitRegexMatch() {
-		return array(
-			array( '' ),
-		);
+		return [
+			[ '' ],
+		];
 	}
 
 	/**
@@ -143,21 +143,21 @@ class BasicNumberUnlocalizerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function provideGetUnitRegexMismatch() {
-		return array(
-			array( ' ' ),
+		return [
+			[ ' ' ],
 
-			array( '^' ),
-			array( '/' ),
+			[ '^' ],
+			[ '/' ],
 
-			array( 'x^' ),
-			array( 'x/' ),
+			[ 'x^' ],
+			[ 'x/' ],
 
-			array( '2' ),
-			array( '2b' ),
+			[ '2' ],
+			[ '2b' ],
 
-			array( '~' ),
-			array( '#' ),
-		);
+			[ '~' ],
+			[ '#' ],
+		];
 	}
 
 	/**

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -37,9 +37,9 @@ class DecimalParserTest extends StringValueParserTest {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = array();
+		$argLists = [];
 
-		$valid = array(
+		$valid = [
 			'0' => 0,
 			'-0' => 0,
 			'-00.00' => '-0.00',
@@ -67,14 +67,14 @@ class DecimalParserTest extends StringValueParserTest {
 			'100,000' => 100000,
 			'100 000' => 100000,
 			'100\'000' => 100000,
-		);
+		];
 
 		foreach ( $valid as $value => $expected ) {
 			// Because PHP turns them into ints using black magic
 			$value = (string)$value;
 
 			$expected = new DecimalValue( $expected );
-			$argLists[] = array( $value, $expected );
+			$argLists[] = [ $value, $expected ];
 		}
 
 		return $argLists;
@@ -86,7 +86,7 @@ class DecimalParserTest extends StringValueParserTest {
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 
-		$invalid = array(
+		$invalid = [
 			'foo',
 			'',
 			'--1',
@@ -96,10 +96,10 @@ class DecimalParserTest extends StringValueParserTest {
 			'1+1',
 			'1-1',
 			'1.2.3',
-		);
+		];
 
 		foreach ( $invalid as $value ) {
-			$argLists[] = array( $value );
+			$argLists[] = [ $value ];
 		}
 
 		return $argLists;
@@ -130,20 +130,20 @@ class DecimalParserTest extends StringValueParserTest {
 	}
 
 	public function splitDecimalExponentProvider() {
-		return array(
-			'trailing newline' => array( "1.2E3\n", '1.2', 3 ),
-			'whitespace' => array( ' 1.2E3 ', ' 1.2E3 ', 0 ),
-			'no exponent' => array( '1.2', '1.2', 0 ),
-			'exponent' => array( '1.2E3', '1.2', 3 ),
-			'negative exponent' => array( '+1.2e-2', '+1.2', -2 ),
-			'positive exponent' => array( '-12e+3', '-12', 3 ),
-			'leading zero' => array( '12e+09', '12', 9 ),
-			'trailing decimal point' => array( '12.e+3', '12.', 3 ),
-			'leading decimal point' => array( '.12e+3', '.12', 3 ),
-			'space' => array( '12 e+3', '12 ', 3 ),
-			'x10 syntax' => array( '12x10^3', '12', 3 ),
-			'comma' => array( '12e3,4', '12', 34 ),
-		);
+		return [
+			'trailing newline' => [ "1.2E3\n", '1.2', 3 ],
+			'whitespace' => [ ' 1.2E3 ', ' 1.2E3 ', 0 ],
+			'no exponent' => [ '1.2', '1.2', 0 ],
+			'exponent' => [ '1.2E3', '1.2', 3 ],
+			'negative exponent' => [ '+1.2e-2', '+1.2', -2 ],
+			'positive exponent' => [ '-12e+3', '-12', 3 ],
+			'leading zero' => [ '12e+09', '12', 9 ],
+			'trailing decimal point' => [ '12.e+3', '12.', 3 ],
+			'leading decimal point' => [ '.12e+3', '.12', 3 ],
+			'space' => [ '12 e+3', '12 ', 3 ],
+			'x10 syntax' => [ '12x10^3', '12', 3 ],
+			'comma' => [ '12e3,4', '12', 34 ],
+		];
 	}
 
 	/**
@@ -158,11 +158,11 @@ class DecimalParserTest extends StringValueParserTest {
 	}
 
 	public function applyDecimalExponentProvider() {
-		return array(
-			'no exponent' => array( new DecimalValue( '+1.2' ), 0, new DecimalValue( '+1.2' ) ),
-			'negative exponent' => array( new DecimalValue( '-1.2' ), -2, new DecimalValue( '-0.012' ) ),
-			'positive exponent' => array( new DecimalValue( '-12' ), 3, new DecimalValue( '-12000' ) ),
-		);
+		return [
+			'no exponent' => [ new DecimalValue( '+1.2' ), 0, new DecimalValue( '+1.2' ) ],
+			'negative exponent' => [ new DecimalValue( '-1.2' ), -2, new DecimalValue( '-0.012' ) ],
+			'positive exponent' => [ new DecimalValue( '-12' ), 3, new DecimalValue( '-12000' ) ],
+		];
 	}
 
 	/**

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -65,7 +65,7 @@ class QuantityParserTest extends StringValueParserTest {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$amounts = array(
+		$amounts = [
 			// amounts in various styles and forms
 			'0' => UnboundedQuantityValue::newFromNumber( 0 ),
 			'-0' => UnboundedQuantityValue::newFromNumber( 0 ),
@@ -129,13 +129,13 @@ class QuantityParserTest extends StringValueParserTest {
 			'100003 m³' => UnboundedQuantityValue::newFromNumber( 100003, 'm³' ),
 			'3.±-0.2µ' => QuantityValue::newFromNumber( '+3', 'µ', '+3.2', '+2.8' ),
 			'+00.20 Å' => UnboundedQuantityValue::newFromNumber( '+0.20', 'Å' ),
-		);
+		];
 
-		$argLists = array();
+		$argLists = [];
 
 		foreach ( $amounts as $amount => $expected ) {
 			//NOTE: PHP may "helpfully" have converted $amount to an integer. Yay.
-			$argLists[$amount] = array( strval( $amount ), $expected );
+			$argLists[$amount] = [ strval( $amount ), $expected ];
 		}
 
 		return $argLists;
@@ -147,7 +147,7 @@ class QuantityParserTest extends StringValueParserTest {
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 
-		$invalid = array(
+		$invalid = [
 			'foo',
 			'',
 			'.',
@@ -188,10 +188,10 @@ class QuantityParserTest extends StringValueParserTest {
 
 			'100 003',
 			'1 . 0',
-		);
+		];
 
 		foreach ( $invalid as $value ) {
-			$argLists[] = array( $value );
+			$argLists[] = [ $value ];
 		}
 
 		return $argLists;
@@ -203,10 +203,10 @@ class QuantityParserTest extends StringValueParserTest {
 
 		$unlocalizer = $this->getMock( NumberUnlocalizer::class );
 
-		$charmap = array(
+		$charmap = [
 			' ' => '',
 			',' => '.',
-		);
+		];
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'unlocalizeNumber' )
@@ -247,13 +247,13 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	public function unitOptionProvider() {
-		return array(
-			array( '17 kittens', null, 'kittens' ),
-			array( '17', 'kittens', 'kittens' ),
-			array( '17 kittens', 'kittens', 'kittens' ),
-			array( '17m', 'm', 'm' ),
-			array( ' 17 ', ' http://concept.uri ', 'http://concept.uri' ),
-		);
+		return [
+			[ '17 kittens', null, 'kittens' ],
+			[ '17', 'kittens', 'kittens' ],
+			[ '17 kittens', 'kittens', 'kittens' ],
+			[ '17m', 'm', 'm' ],
+			[ ' 17 ', ' http://concept.uri ', 'http://concept.uri' ],
+		];
 	}
 
 	/**
@@ -270,11 +270,11 @@ class QuantityParserTest extends StringValueParserTest {
 	}
 
 	public function conflictingUnitOptionProvider() {
-		return array(
-			array( '17 kittens', 'm' ),
-			array( '17m', 'kittens' ),
-			array( '17m', '' ),
-		);
+		return [
+			[ '17 kittens', 'm' ],
+			[ '17m', 'kittens' ],
+			[ '17m', '' ],
+		];
 	}
 
 }


### PR DESCRIPTION
I had to disable two unrelated PHPCS rules. The operator spacing is fixed in #99. The rule about spaces in comments will stay disabled, see #102.