### PR TITLE
Fix HHVM tests failing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer install --prefer-source
 
 script:
-  - phpunit
+  - composer test
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
   - hhvm
 
 before_script:


### PR DESCRIPTION
Everything on Travis is currently blowing up because of this, see https://github.com/travis-ci/travis-ci/issues/7712. I would like to rebase the patches that are waiting for a review here, and need this fix to make the tests succeed again.

This also adds PHP 7.1 to the test matrix in addition to PHP 7.0 and HHVM.