### PR TITLE
Less strict array req in UnboundedQuantityValue::newFromArray

### DIFF
--- a/src/DataValues/UnboundedQuantityValue.php
+++ b/src/DataValues/UnboundedQuantityValue.php
@@ -251,12 +251,12 @@ class UnboundedQuantityValue extends DataValueObject {
 	 * depending on the serialization provided. Required for @see DataValueDeserializer. This can
 	 * round-trip with both @see self::getArrayValue as well as @see QuantityValue::getArrayValue.
 	 *
-	 * @param array $data
+	 * @param mixed $data
 	 *
 	 * @return self|QuantityValue Either an unbounded or bounded quantity value object.
 	 * @throws IllegalValueException
 	 */
-	public static function newFromArray( array $data ) {
+	public static function newFromArray( $data ) {
 		self::requireArrayFields( $data, [ 'amount', 'unit' ] );
 
 		if ( !isset( $data['upperBound'] ) && !isset( $data['lowerBound'] ) ) {

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -156,6 +156,15 @@ class UnboundedQuantityValueTest extends DataValueTest {
 
 	public function invalidArraySerializationProvider() {
 		return [
+			'not an array (string)' => [
+				'foo'
+			],
+			'not an array (int)' => [
+				303
+			],
+			'not an array (object)' => [
+				new \stdClass()
+			],
 			'no-amount' => [
 				[
 					'unit' => '1',


### PR DESCRIPTION
Users of newFromArray give no guarantee that the value passed in
is actually the array. DataValueObject::requireArrayFields
asserts that the value is an array, and throws the exception
that callers can handle. Having no strict array requirement
lets callers handle erroneous input nicer.
Other DataValue classes already seem to follow similar pattern.

Strict array requirement was related to:
https://phabricator.wikimedia.org/T168681