### PR TITLE
Drop backwards compatibility with old commons/interfaces modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
 	"require": {
 		"php": ">=5.5.9",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "~0.2.0|~0.1.5",
-		"data-values/common": "~0.4.0|~0.3.0|~0.2.0"
+		"data-values/interfaces": "~0.2.0",
+		"data-values/common": "~0.4.0|~0.3.0"
 	},
 	"require-dev": {
 		"ext-bcmath": "*",

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -19,13 +19,6 @@ use ValueFormatters\NumberLocalizer;
 class DecimalFormatterTest extends ValueFormatterTestBase {
 
 	/**
-	 * @deprecated since DataValues Interfaces 0.2, just use getInstance.
-	 */
-	protected function getFormatterClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueFormatterTestBase::getInstance
 	 *
 	 * @param FormatterOptions|null $options

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -21,13 +21,6 @@ use ValueFormatters\ValueFormatter;
 class QuantityFormatterTest extends ValueFormatterTestBase {
 
 	/**
-	 * @deprecated since DataValues Interfaces 0.2, just use getInstance.
-	 */
-	protected function getFormatterClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueFormatterTestBase::getInstance
 	 *
 	 * @param FormatterOptions|null $options

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -19,13 +19,6 @@ use ValueFormatters\ValueFormatter;
 class QuantityHtmlFormatterTest extends ValueFormatterTestBase {
 
 	/**
-	 * @deprecated since DataValues Interfaces 0.2, just use getInstance.
-	 */
-	protected function getFormatterClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueFormatterTestBase::getInstance
 	 *
 	 * @param FormatterOptions|null $options

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -18,13 +18,6 @@ use ValueParsers\NumberUnlocalizer;
 class DecimalParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return DecimalParser

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -21,13 +21,6 @@ use ValueParsers\ValueParser;
 class QuantityParserTest extends StringValueParserTest {
 
 	/**
-	 * @deprecated since DataValues Common 0.3, just use getInstance.
-	 */
-	protected function getParserClass() {
-		throw new \LogicException( 'Should not be called, use getInstance' );
-	}
-
-	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
 	 * @return QuantityParser


### PR DESCRIPTION
This was there to maximize compatibility for a while. Long enough.

Note this is **not** a breaking change.