### PR TITLE
Remove duplicate is_string check from QuantityParser

### DIFF
--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -7,7 +7,6 @@ use DataValues\DecimalValue;
 use DataValues\IllegalValueException;
 use DataValues\QuantityValue;
 use DataValues\UnboundedQuantityValue;
-use InvalidArgumentException;
 
 /**
  * ValueParser that parses the string representation of a quantity.
@@ -139,16 +138,11 @@ class QuantityParser extends StringValueParser {
 	 *
 	 * @param string $value
 	 *
-	 * @throws InvalidArgumentException If $value is not a string
 	 * @throws ParseException If $value does not match the expected pattern
 	 * @return array list( $amount, $exactness, $margin, $unit ).
 	 *         Parts not present in $value will be null
 	 */
 	private function splitQuantityString( $value ) {
-		if ( !is_string( $value ) ) {
-			throw new InvalidArgumentException( '$value must be a string' );
-		}
-
 		//TODO: allow explicitly specifying the number of significant figures
 		//TODO: allow explicitly specifying the uncertainty interval
 


### PR DESCRIPTION
This is already checked by the base class. The $value passed to stringParse is guaranteed to be a string (hence the name of the method).

Please merge https://github.com/DataValues/Time/pull/139 along with this, as it is the same patch in an other component.