### PR TITLE
Release 0.10.0 with refined float to string conversion

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -15,4 +15,4 @@ if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_NUMBER_VERSION', '0.9.1' );
+define( 'DATAVALUES_NUMBER_VERSION', '0.10.0' );

--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ the [Wikidata project](https://www.wikidata.org/).
 
 ## Release notes
 
+### 0.10.0 (2018-04-10)
+
+* Changed the float to string conversion algorithm for `DecimalValue`, `QuantityValue`, and
+  `UnboundedQuantityValue`. Instead of a hundred mostly irrelevant decimal places it now uses PHP's
+  "serialize_precision" default of 17 significant digits.
+* Drop compatibility with data-values/interfaces 0.1 and data-values/common 0.2
+
 ### 0.9.1 (2017-08-09)
 
-* Allow use with ~0.4.0 of DataValues/Common
+* Allow use with data-values/common 0.4
 
 ### 0.9.0 (2017-08-09)
 
@@ -103,7 +110,7 @@ the [Wikidata project](https://www.wikidata.org/).
 #### Other changes
 * Fixed `DecimalValue` and `QuantityValue` allowing values with a newline at the end.
 * `DecimalValue` strings are trimmed now, allowing any number of leading and trailing whitespace.
-* Added explicit compatibility with DataValues Common 0.2 and 0.3.
+* Added explicit compatibility with data-values/common 0.2 and 0.3.
 
 ### 0.6.0 (2015-09-09)
 

--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -91,7 +91,17 @@ class DecimalValue extends DataValueObject {
 			throw new InvalidArgumentException( '$number must not be NAN or INF.' );
 		}
 
-		$decimal = strval( abs( $number ) );
+		/**
+		 * As PHP has no other built-in way to format a float with a given number of significant
+		 * digits, use serialize(). While strval() would also work here, it is locale-dependent.
+		 * Intentionally enforce the bigger "serialize_precision" default of 17 to ensure a full
+		 * float-string-float roundtrip.
+		 * @see http://php.net/manual/en/ini.core.php#ini.serialize-precision
+		 */
+		$originalPrecision = ini_set( 'serialize_precision', '17' );
+		$decimal = substr( serialize( abs( $number ) ), 2, -1 );
+		ini_set( 'serialize_precision', $originalPrecision );
+
 		$decimal = preg_replace_callback(
 			'/(\d*)\.(\d*)E([-+]\d+)/i',
 			function ( $matches ) {

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -98,7 +98,10 @@ class DecimalValueTest extends DataValueTest {
 	 * @dataProvider provideFloats
 	 */
 	public function testFloatInputs( $float, $expectedPrefix ) {
+		$originalLocale = setlocale( LC_NUMERIC, '0' );
+		setlocale( LC_NUMERIC, 'de_DE.utf8' );
 		$value = DecimalValue::newFromArray( $float );
+		setlocale( LC_NUMERIC, $originalLocale );
 
 		$this->assertStringStartsWith( $expectedPrefix, $value->getValue(), 'getValue' );
 	}
@@ -179,38 +182,61 @@ class DecimalValueTest extends DataValueTest {
 	/**
 	 * @dataProvider getValueProvider
 	 */
-	public function testGetValue( DecimalValue $value, $expected ) {
-		$actual = $value->getValue();
+	public function testGetValue( $value, $expected ) {
+		$precision = ini_set( 'serialize_precision', '2' );
+		$actual = ( new DecimalValue( $value ) )->getValue();
+		ini_set( 'serialize_precision', $precision );
+
 		$this->assertSame( $expected, $actual );
 	}
 
 	public function getValueProvider() {
 		$argLists = [];
 
-		$argLists[] = [ new DecimalValue( 42 ), '+42' ];
-		$argLists[] = [ new DecimalValue( -42 ), '-42' ];
-		$argLists[] = [ new DecimalValue( -42.0 ), '-42' ];
-		$argLists[] = [ new DecimalValue( '-42' ), '-42' ];
-		$argLists[] = [ new DecimalValue( 4.5 ), '+4.5' ];
-		$argLists[] = [ new DecimalValue( -4.5 ), '-4.5' ];
-		$argLists[] = [ new DecimalValue( '+4.2' ), '+4.2' ];
-		$argLists[] = [ new DecimalValue( 0 ), '+0' ];
-		$argLists[] = [ new DecimalValue( 0.0 ), '+0' ];
-		$argLists[] = [ new DecimalValue( 1.0 ), '+1' ];
-		$argLists[] = [ new DecimalValue( 0.5 ), '+0.5' ];
-		$argLists[] = [ new DecimalValue( '-0.42' ), '-0.42' ];
-		$argLists[] = [ new DecimalValue( '-0.0' ), '+0.0' ];
-		$argLists[] = [ new DecimalValue( '-0' ), '+0' ];
-		$argLists[] = [ new DecimalValue( '+0.0' ), '+0.0' ];
-		$argLists[] = [ new DecimalValue( '+0' ), '+0' ];
-		$argLists[] = [ new DecimalValue( 2147483649 ), '+2147483649' ];
-		$argLists[] = [ new DecimalValue( 1000000000000000 ), '+1000000000000000' ];
+		$argLists[] = [ 42, '+42' ];
+		$argLists[] = [ -42, '-42' ];
+		$argLists[] = [ -42.0, '-42' ];
+		$argLists[] = [ '-42', '-42' ];
+		$argLists[] = [ 4.5, '+4.5' ];
+		$argLists[] = [ -4.5, '-4.5' ];
+		$argLists[] = [ '+4.2', '+4.2' ];
+		$argLists[] = [ 0, '+0' ];
+		$argLists[] = [ 0.0, '+0' ];
+		$argLists[] = [ 1.0, '+1' ];
+		$argLists[] = [ 0.5, '+0.5' ];
+		$argLists[] = [ '-0.42', '-0.42' ];
+		$argLists[] = [ '-0.0', '+0.0' ];
+		$argLists[] = [ '-0', '+0' ];
+		$argLists[] = [ '+0.0', '+0.0' ];
+		$argLists[] = [ '+0', '+0' ];
+		$argLists[] = [ 2147483649, '+2147483649' ];
+		$argLists[] = [ 1000000000000000, '+1000000000000000' ];
 		$argLists[] = [
-			new DecimalValue( 1 + 1e-12 / 3 ),
-			'+1.0000000000003'
+			1 + 1e-12 / 3,
+			'+1.0000000000003333'
 		];
 		$argLists[] = [
-			new DecimalValue( 1 + 1e-14 / 3 ),
+			1 + 1e-13 / 3,
+			'+1.0000000000000333'
+		];
+		$argLists[] = [
+			1 + 1e-14 / 3,
+			'+1.0000000000000033'
+		];
+		$argLists[] = [
+			1 + 1e-15 / 3,
+			'+1.0000000000000004'
+		];
+		$argLists[] = [
+			1 + 1e-16 / 3,
+			'+1'
+		];
+		$argLists[] = [
+			1 - 1e-16,
+			'+0.99999999999999989'
+		];
+		$argLists[] = [
+			1 - 1e-17,
 			'+1'
 		];
 


### PR DESCRIPTION
I played around with the float-to-string conversion, tried a lot of different approaches I already tried before, and found a new one:
* I looked into PHP's "precision" setting. It defaults to 14. I found this problematic for two reasons:
  1. After #115 this code started to depend on local configuration.
  2. I found 14 not enough. ECMAScript for example outputs about 17 significant digits.
* I tried json_encode, but found it uses the same "precision" setting.
* I found a "serialize_precision" setting that defaults to 17. This fits much better to what this code is meant to do: The string is meant to be a serialization, not to be looked at by a human. With 17 places the output might end with 1 or 2 partially messed up digits. For example, you might end with "0.99999999999999989" instead of the expected "0.99999999999999999". This is because of the IEEE conversion. What's relevant: With 17 places the string is guaranteed to become the same IEEE floating point number when converted back.

This patch fixes two of the listed issues, and (I believe) avoids all others:
* The default of 17 significant digits is used and enforced.
* Because it now uses PHP's `serialize()`, the locale does not matter any more.

[Bug: T155910](https://phabricator.wikimedia.org/T155910)