### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ the [Wikidata project](https://www.wikidata.org/).
 
 ## Release notes
 
+### 0.13.0 (2024-12-10)
+
+* Drop support for PHP 7.2, 7.3
+* Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
+* Make nullable type parameter declarations explicit for compatibility with PHP 8.4
+
 ### 0.12.3 (2022-10-24)
 
 * Allow use with data-values/common 1.1.0 and data-values/interfaces 1.x


### PR DESCRIPTION
 * Drop support for PHP 7.2, 7.3
 * Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
 * Make nullable type parameter declarations explicit for compatibility with PHP 8.4